### PR TITLE
Copyright and Footer Improvements

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,6 +2,8 @@
   {{/* Copyright */}}
   <p class="text-neutral-400 dark:text-neutral-500">
     {{- with .Site.Copyright }}
+      &copy;
+      {{ now.Format "2006" }}
       {{ . | emojify | markdownify }}
     {{- else }}
       &copy;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,8 @@
 <footer class="py-10 text-sm">
+  {{/* Footer Pre */}}
+  {{ if templates.Exists "partials/pre-footer.html" }}
+    {{ partialCached "pre-footer.html" . }}
+  {{ end }}
   {{/* Copyright */}}
   <p class="text-neutral-400 dark:text-neutral-500">
     {{- with .Site.Copyright }}


### PR DESCRIPTION
* Added support for pre-footer partial which can enable users to add sitelinks to all sites, above the copyright
* Also enabled year/copyright symbol even when site.copyright is set.