### PR TITLE
Fix spacing for pagination dates

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1928,8 +1928,8 @@ body a, body button {
   margin-right: 0.75rem;
 }
 
-.-mt-1 {
-  margin-top: -0.25rem;
+.mt-\[0\.1rem\] {
+  margin-top: 0.1rem;
 }
 
 .ml-3 {
@@ -2336,12 +2336,12 @@ body a, body button {
   line-height: 1.75rem;
 }
 
-.leading-3 {
-  line-height: .75rem;
-}
-
 .leading-6 {
   line-height: 1.5rem;
+}
+
+.leading-3 {
+  line-height: .75rem;
 }
 
 .text-neutral-400 {

--- a/layouts/partials/article-pagination.html
+++ b/layouts/partials/article-pagination.html
@@ -9,7 +9,7 @@
               <span class="mr-3 article-pagination-direction">&larr;</span>
               <span class="flex flex-col">
                 <span class="article-pagination-title">{{ .NextInSection.Title | emojify }}</span>
-                <span class="-mt-1 text-xs text-neutral-400 dark:text-neutral-500">
+                <span class="text-xs text-neutral-400 dark:text-neutral-500">
                   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
                     {{ partial "meta/date.html" . }}
                   {{ end }}
@@ -23,7 +23,7 @@
             <a class="flex text-right" href="{{ .PrevInSection.RelPermalink }}">
               <span class="flex flex-col">
                 <span class="article-pagination-title">{{ .PrevInSection.Title | emojify }}</span>
-                <span class="-mt-1 text-xs text-neutral-400 dark:text-neutral-500">
+                <span class="text-xs text-neutral-400 dark:text-neutral-500">
                   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
                     {{ partial "meta/date.html" . }}
                   {{ end }}

--- a/layouts/partials/article-pagination.html
+++ b/layouts/partials/article-pagination.html
@@ -8,8 +8,10 @@
             <a class="flex" href="{{ .NextInSection.RelPermalink }}">
               <span class="mr-3 article-pagination-direction">&larr;</span>
               <span class="flex flex-col">
-                <span class="article-pagination-title">{{ .NextInSection.Title | emojify }}</span>
-                <span class="text-xs text-neutral-400 dark:text-neutral-500">
+                <span class="article-pagination-title mt-[0.1rem] leading-6"
+                  >{{ .NextInSection.Title | emojify }}</span
+                >
+                <span class="mt-[0.1rem] text-xs text-neutral-400 dark:text-neutral-500">
                   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
                     {{ partial "meta/date.html" . }}
                   {{ end }}
@@ -22,8 +24,10 @@
           {{ if .PrevInSection }}
             <a class="flex text-right" href="{{ .PrevInSection.RelPermalink }}">
               <span class="flex flex-col">
-                <span class="article-pagination-title">{{ .PrevInSection.Title | emojify }}</span>
-                <span class="text-xs text-neutral-400 dark:text-neutral-500">
+                <span class="article-pagination-title mt-[0.1rem] leading-6"
+                  >{{ .PrevInSection.Title | emojify }}</span
+                >
+                <span class="mt-[0.1rem] text-xs text-neutral-400 dark:text-neutral-500">
                   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
                     {{ partial "meta/date.html" . }}
                   {{ end }}


### PR DESCRIPTION
Before and after:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/13618205/140436024-31398ddd-c50d-4f36-a55f-8259d61c6315.png">

With the current styling, I think the spacing is too cramped in the pagination. This PR uses the default margin instead. 