### PR TITLE
Add parentheses in date.html

### DIFF
--- a/layouts/partials/meta/date.html
+++ b/layouts/partials/meta/date.html
@@ -1,10 +1,10 @@
 <time datetime="{{ .Date }}">
-  {{- .Date.Format .Site.Params.article.dateFormat | default "2 January 2006" -}}
+  {{- .Date.Format (.Site.Params.article.dateFormat | default "2 January 2006") -}}
 </time>
 {{ if .Params.showDateUpdated | default (.Site.Params.article.showDateUpdated | default false) }}
   &nbsp;(Updated:&nbsp;
   <time datetime="{{ .Lastmod }}">
-    {{- .Lastmod.Format .Site.Params.article.dateFormat | default "2 January 2006" -}}
+    {{- .Lastmod.Format (.Site.Params.article.dateFormat | default "2 January 2006") -}}
   </time>
   )
 {{ end }}


### PR DESCRIPTION
When following this [workflow](https://bookdown.org/yihui/blogdown/workflow.html), there is an error when serving the site :

![Screenshot 2021-12-27 at 11 55 18](https://user-images.githubusercontent.com/17910063/147465917-0ccb9f3b-ee20-4fbb-9524-e1c3f0d7356e.png)

By adding these parentheses, the site is served without any error.

Regards,
Antoine

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
