### PR TITLE
🐛  add emojify for title on list page and browser / tab title

### DIFF
--- a/layouts/partials/article-link.html
+++ b/layouts/partials/article-link.html
@@ -6,7 +6,7 @@
         href="{{ . }}"
         target="_blank"
         rel="external"
-        >{{ $.Title }}</a
+        >{{ $.Title | emojify }}</a
       >
       <span
         class="-mt-2 text-xs cursor-default text-neutral-400 dark:text-neutral-500"
@@ -18,7 +18,7 @@
       <a
         class="hover:underline hover:underline-primary-500 hover:underline-offset-small text-neutral-800 dark:text-neutral"
         href="{{ .RelPermalink }}"
-        >{{ .Title }}</a
+        >{{ .Title | emojify }}</a
       >
     {{ end }}
     {{ if and .Draft .Site.Params.article.showDraftLabel }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,7 +30,7 @@
   {{ end }}
   <link rel="canonical" href="{{ .Permalink }}" />
   {{ range .AlternativeOutputFormats -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML | emojify }}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink ($.Site.Title | emojify) | safeHTML }}
   {{ end -}}
   {{/* Styles */}}
   {{ $schemeCSS := resources.Get (printf "css/schemes/%s.css" (.Site.Params.colorScheme | default "congo")) }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,7 +10,7 @@
     <title>{{ .Site.Title }}</title>
     <meta name="title" content="{{ .Site.Title }}" />
   {{- else -}}
-    <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
+    <title>{{ .Title | emojify }} &middot; {{ .Site.Title }}</title>
     <meta name="title" content="{{ .Title }} &middot; {{ .Site.Title }}" />
   {{- end }}
   {{/* Metadata */}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,11 +7,11 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   {{/* Title */}}
   {{ if .IsHome -}}
-    <title>{{ .Site.Title }}</title>
-    <meta name="title" content="{{ .Site.Title }}" />
+    <title>{{ .Site.Title | emojify }}</title>
+    <meta name="title" content="{{ .Site.Title | emojify }}" />
   {{- else -}}
-    <title>{{ .Title | emojify }} &middot; {{ .Site.Title }}</title>
-    <meta name="title" content="{{ .Title }} &middot; {{ .Site.Title }}" />
+    <title>{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}</title>
+    <meta name="title" content="{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}" />
   {{- end }}
   {{/* Metadata */}}
   {{ with .Params.Description -}}
@@ -30,7 +30,7 @@
   {{ end }}
   <link rel="canonical" href="{{ .Permalink }}" />
   {{ range .AlternativeOutputFormats -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML | emojify }}
   {{ end -}}
   {{/* Styles */}}
   {{ $schemeCSS := resources.Get (printf "css/schemes/%s.css" (.Site.Params.colorScheme | default "congo")) }}


### PR DESCRIPTION
Fix for #83 which transforms text to emojis, e.g.  `:book:`  to  📖 

Updates are on:
- article-link.html (effects content title in list views)  
  ![image](https://user-images.githubusercontent.com/750874/150027756-3ddb9de6-cd24-4bba-a658-4b49273cf981.png)

- head.html (effects browser / tab title)
  ![image](https://user-images.githubusercontent.com/750874/150027799-160c77a9-bdb9-418c-aba8-bc1999b5b4f3.png)


