### PR TITLE
💄 Adjust metadata output

### DIFF
--- a/exampleSite/content/samples/placeholder-text.md
+++ b/exampleSite/content/samples/placeholder-text.md
@@ -1,9 +1,11 @@
 ---
 title: "Placeholder Text"
 date: "2019-03-09"
+lastmod: "2022-01-24"
 draft: true
 description: "Lorem Ipsum Dolor Si Amet"
 tags: ["markdown", "text", "sample", "latin"]
+showDateUpdated: true
 xml: false
 ---
 

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -6,6 +6,7 @@ article:
     one: "{{ .Count }} min"
     other: "{{ .Count }} min"
   reading_time_title: "Lesezeit"
+  # updated: "Updated"
   # word_count:
   # one: "{{ .Count }} word"
   # other: "{{ .Count }} words"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -6,6 +6,7 @@ article:
     one: "{{ .Count }} min"
     other: "{{ .Count }} mins"
   reading_time_title: "Reading time"
+  updated: "Updated"
   word_count:
     one: "{{ .Count }} word"
     other: "{{ .Count }} words"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -6,9 +6,10 @@ article:
     one: "{{ .Count }} min"
     other: "{{ .Count }} mins"
   reading_time_title: "Tiempo de lectura"
-  # word_count:
-  # one: "{{ .Count }} word"
-  # other: "{{ .Count }} words"
+  updated: "Actualizado"
+  word_count:
+    one: "{{ .Count }} palabra"
+    other: "{{ .Count }} palabras"
 
 author:
   byline_title: "Autor"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -6,6 +6,7 @@ article:
     one: "{{ .Count }} min"
     other: "{{ .Count }} mins"
   reading_time_title: "Temps de lecture"
+  # updated: "Updated"
   # word_count:
   # one: "{{ .Count }} word"
   # other: "{{ .Count }} words"

--- a/i18n/pt-BR.yaml
+++ b/i18n/pt-BR.yaml
@@ -6,6 +6,7 @@ article:
     one: "{{ .Count }} minuto"
     other: "{{ .Count }} minutos"
   reading_time_title: "Tempo de leitura"
+  # updated: "Updated"
   # word_count:
   # one: "{{ .Count }} word"
   # other: "{{ .Count }} words"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -6,6 +6,7 @@ article:
     one: "{{ .Count }} dk"
     other: "{{ .Count }} dk"
   reading_time_title: "Okuma süresi"
+  # updated: "Updated"
   word_count:
     one: "{{ .Count }} kelime"
     other: "{{ .Count }} kelime"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -5,6 +5,7 @@ article:
   reading_time:
     other: "{{ .Count }} 分钟"
   reading_time_title: "预计阅读"
+  # updated: "Updated"
   word_count:
     one: "{{ .Count }} 字"
     other: "{{ .Count }} 字"

--- a/layouts/partials/article-meta.html
+++ b/layouts/partials/article-meta.html
@@ -33,7 +33,7 @@
   {{ end }}
 
 
-  <div class="flex flex-row items-center">
+  <div class="flex flex-row flex-wrap items-center">
     {{/* Output partials */}}
     {{ with ($meta.Get "partials") }}
       {{ delimit . "<span class=\"px-2 text-primary-500\">&middot;</span>" }}

--- a/layouts/partials/article-meta.html
+++ b/layouts/partials/article-meta.html
@@ -13,7 +13,11 @@
 
   {{/* Gather partials for this context */}}
   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
-    {{ $meta.Add "partials" (slice (partial "meta/date.html" .)) }}
+    {{ $meta.Add "partials" (slice (partial "meta/date.html" .Date)) }}
+  {{ end }}
+
+  {{ if .Params.showDateUpdated | default (.Site.Params.article.showDateUpdated | default false) }}
+    {{ $meta.Add "partials" (slice (partial "meta/date-updated.html" .Lastmod)) }}
   {{ end }}
 
   {{ if and (.Params.showWordCount | default (.Site.Params.article.showWordCount | default false)) (ne .WordCount 0) }}

--- a/layouts/partials/article-pagination.html
+++ b/layouts/partials/article-pagination.html
@@ -13,7 +13,7 @@
                 >
                 <span class="mt-[0.1rem] text-xs text-neutral-500 dark:text-neutral-400">
                   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
-                    {{ partial "meta/date.html" .NextInSection }}
+                    {{ partial "meta/date.html" .NextInSection.Date }}
                   {{ end }}
                 </span>
               </span>
@@ -29,7 +29,7 @@
                 >
                 <span class="mt-[0.1rem] text-xs text-neutral-500 dark:text-neutral-400">
                   {{ if .Params.showDate | default (.Site.Params.article.showDate | default true) }}
-                    {{ partial "meta/date.html" .PrevInSection }}
+                    {{ partial "meta/date.html" .PrevInSection.Date }}
                   {{ end }}
                 </span>
               </span>

--- a/layouts/partials/meta/date-updated.html
+++ b/layouts/partials/meta/date-updated.html
@@ -1,0 +1,3 @@
+{{- i18n "article.updated" -}}:&nbsp;
+{{ partial "meta/date.html" . }}
+{{- /* Trim EOF */ -}}

--- a/layouts/partials/meta/date.html
+++ b/layouts/partials/meta/date.html
@@ -1,4 +1,4 @@
 <time datetime="{{ . }}">
-  {{- . | time.Format (site.Params.article.dateFormat | default "2 January 2006") -}}
+  {{- .Format (site.Params.article.dateFormat | default "2 January 2006") -}}
 </time>
 {{- /* Trim EOF */ -}}

--- a/layouts/partials/meta/date.html
+++ b/layouts/partials/meta/date.html
@@ -1,11 +1,4 @@
-<time datetime="{{ .Date }}">
-  {{- .Date.Format (.Site.Params.article.dateFormat | default "2 January 2006") -}}
+<time datetime="{{ . }}">
+  {{- . | time.Format (site.Params.article.dateFormat | default "2 January 2006") -}}
 </time>
-{{ if .Params.showDateUpdated | default (.Site.Params.article.showDateUpdated | default false) }}
-  &nbsp;(Updated:&nbsp;
-  <time datetime="{{ .Lastmod }}">
-    {{- .Lastmod.Format (.Site.Params.article.dateFormat | default "2 January 2006") -}}
-  </time>
-  )
-{{ end }}
 {{- /* Trim EOF */ -}}


### PR DESCRIPTION
Hi @jpanther! Per discussion #88:

I have submitted two commits:

1. Add i18n 'Updated' strings: I have added the `article.updated` string to the different languages available, making possible the translations to the last updated date in article's metadata. I've also updated the missing spanish translations of "word" and "words".
2. Adjust metadata output: I have created a new partial called `date-updated.html` which adds the 'Updated' localized string and then calls the `date.html` partial. The new simplified `date.html` also solves a little problem where before it displayed both the date and the updated date on pagination. Then, in `article-meta.html`, instead of showing the last updated date in parentheses, I have treated it like another meta parameter.

This is my first ever pull request, I'm sorry if I did something wrong :sweat_smile: