### PR TITLE
Use the group by year var in the term partial

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -14,8 +14,10 @@
   {{ end }}
   <section>
     {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-      <h2 class="mt-12 text-2xl font-bold first:mt-8">{{ .Key }}</h2>
-      <hr class="border-dotted border-neutral-400 w-36" />
+      {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
+        <h2 class="mt-12 text-2xl font-bold first:mt-8">{{ .Key }}</h2>
+        <hr class="border-dotted border-neutral-400 w-36" />
+      {{ end }}
       {{ range .Pages }}
         {{ partial "article-link.html" . }}
       {{ end }}


### PR DESCRIPTION
hey!

Thanks for open-sourcing this theme :)

This PR just adds the `groupByYear` var in the `term` layout so we could disable the grouping in the taxonomy pages