### PR TITLE
🌐 Fix footer menu display in RTL

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     <nav class="pb-4 text-base font-medium text-neutral-500 dark:text-neutral-400">
       <ul class="flex flex-col list-none sm:flex-row">
         {{ range .Site.Menus.footer }}
-          <li class="mb-1 sm:mb-0 sm:mr-7 sm:last:mr-0">
+          <li class="mb-1 ltr:text-right rtl:text-left sm:mb-0 ltr:sm:mr-7 ltr:sm:last:mr-0 rtl:sm:ml-7 rtl:sm:last:ml-0">
             <a
               class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2"
               href="{{ .URL }}"


### PR DESCRIPTION
The footer menu did not have these `rtl:` modifiers to change the margin direction. This PR adds the modifiers for both LTR and RTL, similar to how it's done in `header.html`.