### PR TITLE
Update example baseUrl in getting started

### DIFF
--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -20,7 +20,7 @@ Before creating any content, there are a few things you should set for a new ins
 ```toml
 # config/_default/config.toml
 
-baseURL = "https://your_domain.com"
+baseURL = "https://your_domain.com/"
 languageCode = "en"
 ```
 


### PR DESCRIPTION
Just in case someone needs it, writing https://your_domain.com as baseURL makes the function fetchJSON in `assets/js/search.js` fetch an url like https://your_domain.comindex.json, so in this scenario the search function does not load the index file since it is not found.

I had the search function not working on my website and later found out the cause, it's just the slash that I forgot to add to the baseURL.
