### PR TITLE
fix Netlify preview deployments

### DIFF
--- a/exampleSite/content/docs/hosting-deployment/index.md
+++ b/exampleSite/content/docs/hosting-deployment/index.md
@@ -100,6 +100,9 @@ Then in the root of your site repository, create a `netlify.toml` file:
 [context.production.environment]
   HUGO_VERSION = "0.100.2"
   HUGO_ENV = "production"
+  
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.100.2"
 ```
 
 This configuration assumes you are deploying Congo as a Hugo module. If you have installed the theme using another method, change the build command to simply `hugo --gc --minify -b $URL`.


### PR DESCRIPTION
Netlify uses an old version of Hugo (0.8x) unless you tell it to use something newer. 0.8x does not support congo as a module so you'll end up with this error in your preview deployments.

```
WARN 2022/06/19 17:47:35 Module "github.com/jpanther/congo/v2" is not compatible with this Hugo version
```

