### PR TITLE
:bug: Fix issue #223, ensure trailing forward slash baseURL during search index build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Search not working when `baseURL` does not end with a forward slash ([#224](https://github.com/jpanther/congo/pull/224))
+
 ## [2.2.2] - 2022-06-16
 
 ### Added

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -107,6 +107,7 @@ function fetchJSON(path, callback) {
 
 function buildIndex() {
   var baseURL = wrapper.getAttribute("data-url");
+  baseURL = baseURL.replace(/\/?$/, '/');
   fetchJSON(baseURL + "index.json", function (data) {
     var options = {
       shouldSort: true,


### PR DESCRIPTION
Fix to issue #223.

Should now hopefully verify that `baseURL` contains a trailing forward slash. This fixes my personal issue with search not working, hopefully it doesn't break anyone else's search.

 