### PR TITLE
feat: :+1:  add Japanese language :jp:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Japanese translation ([#234](https://github.com/jpanther/congo/pull/234))
+
 ### Fixed
 
 - Main content misaligned when hamburger menu is opened at large viewport sizes

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,0 +1,55 @@
+article:
+  anchor_label: "アンカー"
+  date: "{{ .Date }}"
+  date_updated: "更新日: {{ .Date }}"
+  draft: "下書き"
+  edit_title: "編集"
+  reading_time:
+    one: "{{ .Count }} 分"
+    other: "{{ .Count }} 分"
+  reading_time_title: "読むのに必要な時間"
+  table_of_contents: "目次"
+  word_count:
+    one: "{{ .Count }} 文字"
+    other: "{{ .Count }} 文字"
+  
+author:
+  byline_title: "著者"
+
+code:
+  copy: "コピー"
+  copied: "コピーしました"
+
+error:
+  404_title: "ページが見つかりませんでした。 :confused:"
+  404_error: "Error 404"
+  404_description: "ご要望のページは存在しないようです。"
+
+footer:
+  dark_appearance: "ダークモードへ切り替え"
+  light_appearance: "ライトモードへ切り替え"
+  powered_by: "Powered by {{ .Hugo }} &amp; {{ .Congo }}"
+
+list:
+  externalurl_title: "外部サイトへリンク"
+  no_articles: "ここに掲載する記事はまだありません。"
+
+nav:
+  scroll_to_top_title: "TOPへスクロール"
+  skip_to_main: "メインコンテンツへスキップ"
+
+search:
+  open_button_title: "検索 (/)"
+  close_button_title: "閉じる (Esc)"
+  input_placeholder: "Search"
+
+sharing:
+  email: " Eメールを送る"
+  facebook: "Facebookでシェアする"
+  linkedin: "LinkedInでシェアする"
+  pinterest: "Pinterestでピンする"
+  reddit: "Redditに投稿する"
+  twitter: "Twitterに投稿する"
+
+shortcode:
+  recent_articles: "最近の記事"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugo-congo-theme",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hugo-congo-theme",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -20,6 +20,9 @@
         "rimraf": "^3.0.2",
         "tailwindcss": "^3.1.4",
         "vendor-copy": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jpanther"
       }
     },
     "node_modules/@braintree/sanitize-url": {


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->

Dear @jpanther ,

I have added the Japanese language file with reference to the English language file.
However, the words in the English language file are familiar to Japanese people, so I don't feel it is necessary to dare to convert them to Japanese.
If someone uses this Japanese language file, `dateFormat` in `languages.ja.toml` should be like `"2006年01月02日"` to be closer to the Japanese convention.
Anyway, I hope it helps you.

P.S.

![Screen Shot 2022-06-29 at 13 00 10](https://user-images.githubusercontent.com/32637762/176349871-886d7cd1-bead-46e2-8d62-ce6a99eb1805.png)

```ja.yaml
footer:
  dark_appearance: "ダークモードへ切り替え"
  light_appearance: "ライトモードへ切り替え"
```

Unfortunately, I was unable to complete the verification for the footer appearance switching section.
It keeps showing "Switching to dark" even when switching from dark to light.
Is this happening only in my environment?