### PR TITLE
feat: :+1: introduce prettier-plugin-tailwindcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugo-congo-theme",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hugo-congo-theme",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -17,6 +17,7 @@
         "mermaid": "^9.1.3",
         "prettier": "^2.7.1",
         "prettier-plugin-go-template": "^0.0.13",
+        "prettier-plugin-tailwindcss": "^0.1.13",
         "rimraf": "^3.0.2",
         "tailwindcss": "^3.1.6",
         "vendor-copy": "^3.0.1"
@@ -1649,6 +1650,18 @@
         "prettier": "^2.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3197,6 +3210,13 @@
       "requires": {
         "ulid": "^2.3.0"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "requires": {}
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mermaid": "^9.1.3",
     "prettier": "^2.7.1",
     "prettier-plugin-go-template": "^0.0.13",
+    "prettier-plugin-tailwindcss": "^0.1.13",
     "rimraf": "^3.0.2",
     "tailwindcss": "^3.1.6",
     "vendor-copy": "^3.0.1"


### PR DESCRIPTION
Hello @jpanther

Congo is using Prettier and Tailwind CSS.
Then you could standardize the coding style of Congo users by installing [tailwindlabs/prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
I used it for about a month in the development of my own site using Congo and had no problems in my environment.
I think it is great that it is an official plugin provided by Tailwind and that we don't have to configure anything just by installing it.
I would be glad if you would consider introducing this plugin.