### PR TITLE
Fix error calling Paginate

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -13,15 +13,17 @@
     </section>
   {{ end }}
   <section>
-    {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-      {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
-        <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-          {{ .Key }}
-        </h2>
-        <hr class="border-dotted w-36 border-neutral-400" />
-      {{ end }}
-      {{ range .Pages }}
-        {{ partial "article-link.html" . }}
+    {{ if .Data.Pages }}
+      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+        {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
+          <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+            {{ .Key }}
+          </h2>
+          <hr class="border-dotted w-36 border-neutral-400" />
+        {{ end }}
+        {{ range .Pages }}
+          {{ partial "article-link.html" . }}
+        {{ end }}
       {{ end }}
     {{ end }}
   </section>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -14,17 +14,30 @@
   {{ end }}
   <section>
     {{ if .Data.Pages }}
-      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+      <section>
         {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
-          <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
-            {{ .Key }}
-          </h2>
-          <hr class="border-dotted w-36 border-neutral-400" />
+          {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+            <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+              {{ .Key }}
+            </h2>
+            <hr class="border-dotted w-36 border-neutral-400" />
+            {{ range .Pages }}
+              {{ partial "article-link.html" . }}
+            {{ end }}
+          {{ end }}
+        {{ else }}
+          {{ range .Paginator.Pages }}
+            {{ partial "article-link.html" . }}
+          {{ end }}
         {{ end }}
-        {{ range .Pages }}
-          {{ partial "article-link.html" . }}
-        {{ end }}
-      {{ end }}
+      </section>
+      {{ partial "pagination.html" . }}
+    {{ else }}
+      <section class="mt-10 prose dark:prose-invert">
+        <p class="py-8 border-t">
+          <em>{{ i18n "list.no_articles" | emojify }}</em>
+        </p>
+      </section>
     {{ end }}
   </section>
   {{ partial "pagination.html" . }}


### PR DESCRIPTION
Fixes issues of hugo v0.102 throwing the following error: `_default/term.html:16:14: executing "main" at <.Paginate>: error calling Paginate: cannot convert type page.PagesGroup to Pages`

I think it was caused by no `terms` set up, but I am no Hugo expert. Could please someone check if I fixed the issue properly?