### PR TITLE
🩹Fix #313 ordering content in a list layout

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -26,14 +26,18 @@
   </section>
   {{ if gt .Pages 0 }}
     <section>
-      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
-        {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
+      {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
+        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
           <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
             {{ .Key }}
           </h2>
           <hr class="border-dotted w-36 border-neutral-400" />
+          {{ range .Pages }}
+            {{ partial "article-link.html" . }}
+          {{ end }}
         {{ end }}
-        {{ range .Pages }}
+      {{ else }}
+        {{ range .Paginator.Pages }}
           {{ partial "article-link.html" . }}
         {{ end }}
       {{ end }}


### PR DESCRIPTION
Fix #313. PR sets pagination and ordering to Hugo's default if `groupByYear` parameter is set `false`. It makes the Congo theme follow [Hugo's convention of ordering content inside list templates](https://gohugo.io/templates/lists/#order-content).

