### PR TITLE
Adding og:image parameter to single

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,7 @@
   {{- $feature := $images.GetMatch "*feature*" | default $cover }}
   <article>
     <header class="max-w-prose">
+	    <meta property="og:image" content="{{ $feature.RelPermalink | absURL }}" />
       {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}
       {{ end }}


### PR DESCRIPTION
Would be nice to add teh meta of:image to the single post so the cover image can be the image highlight when sharing the post

Read:
https://discourse.gohugo.io/t/display-first-image-in-post-in-link-preview/10541

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
