### PR TITLE
Fix: unique meta descriptions from articles

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,9 +14,7 @@
     <meta name="title" content="{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}" />
   {{- end }}
   {{/* Metadata */}}
-  {{ with .Site.Params.description -}}
-    <meta name="description" content="{{ . }}" />
-  {{- end }}
+  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
   {{ with .Site.Params.keywords -}}
     <meta name="keywords" content="{{ . }}" />
   {{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
     <meta name="title" content="{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}" />
   {{- end }}
   {{/* Metadata */}}
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
+  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
   {{ with .Site.Params.keywords -}}
     <meta name="keywords" content="{{ . }}" />
   {{- end }}


### PR DESCRIPTION
fixes :bug: #377

The Meta description tag is now generated from either
1. page description, or
2. Page content summary, or
3. Site wide config

Before

![image](https://user-images.githubusercontent.com/72130/202955261-360f3a8f-bef9-4757-927b-882536fdee46.png)


After

![image](https://user-images.githubusercontent.com/72130/202955187-c27c341a-0129-44cc-b5a3-5b19398db591.png)

