### PR TITLE
💄 Add support for `theme-color` meta tag

### DIFF
--- a/assets/js/appearance.js
+++ b/assets/js/appearance.js
@@ -1,8 +1,16 @@
 const sitePreference = document.documentElement.getAttribute("data-default-appearance");
 const userPreference = localStorage.getItem("appearance");
 
+function setThemeColor() {
+  const metaThemeColor = document.querySelector("meta[name=theme-color]");
+  document.documentElement.classList.contains("dark")
+    ? metaThemeColor.setAttribute("content", "#27272a")
+    : metaThemeColor.setAttribute("content", "#ffffff");
+}
+
 if ((sitePreference === "dark" && userPreference === null) || userPreference === "dark") {
   document.documentElement.classList.add("dark");
+  setThemeColor();
 }
 
 if (document.documentElement.getAttribute("data-auto-appearance") === "true") {
@@ -12,6 +20,7 @@ if (document.documentElement.getAttribute("data-auto-appearance") === "true") {
     userPreference !== "light"
   ) {
     document.documentElement.classList.add("dark");
+    setThemeColor();
   }
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (event) => {
     if (event.matches) {
@@ -19,6 +28,7 @@ if (document.documentElement.getAttribute("data-auto-appearance") === "true") {
     } else {
       document.documentElement.classList.remove("dark");
     }
+    setThemeColor();
   });
 }
 
@@ -27,6 +37,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
   if (switcher) {
     switcher.addEventListener("click", () => {
       document.documentElement.classList.toggle("dark");
+      setThemeColor();
       localStorage.setItem(
         "appearance",
         document.documentElement.classList.contains("dark") ? "dark" : "light"

--- a/assets/js/appearance.js
+++ b/assets/js/appearance.js
@@ -1,11 +1,17 @@
 const sitePreference = document.documentElement.getAttribute("data-default-appearance");
 const userPreference = localStorage.getItem("appearance");
 
+function getCSSValue(varName) {
+  var cssValue = window.getComputedStyle(document.documentElement).getPropertyValue(varName);
+  return "rgb(" + cssValue.replace(/\s+/g, "") + ")";
+}
+
 function setThemeColor() {
-  const metaThemeColor = document.querySelector("meta[name=theme-color]");
+  var metaThemeColor = document.querySelector("meta[name=theme-color]");
   document.documentElement.classList.contains("dark")
-    ? metaThemeColor.setAttribute("content", "#27272a")
-    : metaThemeColor.setAttribute("content", "#ffffff");
+    ? metaThemeColor.setAttribute("content", getCSSValue("--color-neutral-800"))
+    : metaThemeColor.setAttribute("content", getCSSValue("--color-neutral"));
+  return true;
 }
 
 if ((sitePreference === "dark" && userPreference === null) || userPreference === "dark") {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-language" content="{{ . }}" />
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="#ffffff" />
+  <meta name="theme-color" content="rgb(255,255,255)" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   {{/* Title */}}
   {{ if .IsHome -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,6 +4,8 @@
     <meta http-equiv="content-language" content="{{ . }}" />
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#27272a" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   {{/* Title */}}
   {{ if .IsHome -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,8 +4,7 @@
     <meta http-equiv="content-language" content="{{ . }}" />
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
-  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#27272a" />
+  <meta name="theme-color" content="#ffffff" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   {{/* Title */}}
   {{ if .IsHome -}}


### PR DESCRIPTION
Adds the `theme-color` meta tag to `head.html` to provide default background colours to the browser.

Currently only supports static default colours white/dark-grey.

Fixes: #343