### PR TITLE
:bug: Fix render-image.html for SVG

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -15,16 +15,24 @@
   {{ end }}
   {{ with $resource }}
     <figure>
-      <img
-        class="my-0 rounded-md"
-        srcset="
-          {{ (.Resize "330x").RelPermalink }} 330w,
-          {{ (.Resize "660x").RelPermalink }} 660w,
-          {{ (.Resize "1024x").RelPermalink }} 1024w,
-          {{ (.Resize "1320x").RelPermalink }} 2x"
-        src="{{ (.Resize "660x").RelPermalink }}"
-        alt="{{ $altText }}"
-      />
+      {{ if eq .MediaType.SubType "svg" }}
+        <img
+            class="my-0 rounded-md"
+            src="{{ .RelPermalink }}"
+            alt="{{ $altText }}"
+        />
+      {{ else }}
+        <img
+            class="my-0 rounded-md"
+            srcset="
+            {{ (.Resize "330x").RelPermalink }} 330w,
+            {{ (.Resize "660x").RelPermalink }} 660w,
+            {{ (.Resize "1024x").RelPermalink }} 1024w,
+            {{ (.Resize "1320x").RelPermalink }} 2x"
+            src="{{ (.Resize "660x").RelPermalink }}"
+            alt="{{ $altText }}"
+        />
+      {{ end }}
       {{ with $caption }}<figcaption>{{ . | markdownify }}</figcaption>{{ end }}
     </figure>
   {{ else }}


### PR DESCRIPTION
SVG images do not support resizing, so `srcset/src` attributes should be simplified

Fixes #413 

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
