### PR TITLE
Add aria-label to appearance switcher button

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -50,7 +50,7 @@
           ltr:mr-14 rtl:ml-14
         {{- end }} cursor-pointer text-sm text-neutral-700 hover:text-primary-600 dark:text-neutral dark:hover:text-primary-400"
       >
-        <button id="appearance-switcher" type="button">
+        <button id="appearance-switcher" type="button" aria-label="appearance switcher">
           <div
             class="flex items-center justify-center w-12 h-12 dark:hidden"
             title="{{ i18n "footer.dark_appearance" }}"


### PR DESCRIPTION
At the moment we get knocked on the a11y portion of a lighthouse report if using this feature (screenshot below)

<img width="770" alt="image" src="https://user-images.githubusercontent.com/2766321/211939118-a000bb0f-f2a2-40b5-a759-2cbcc46a92b3.png">

This PR adds an `aria-label` which resolves the issue.