### PR TITLE
Fix a11y issues with article-link

### DIFF
--- a/layouts/partials/article-link.html
+++ b/layouts/partials/article-link.html
@@ -10,6 +10,7 @@
         {{ else }}
           {{ $.RelPermalink }}
         {{ end }}"
+        aria-label="{{ $.Title | emojify }}"
       >
         <img
           class="w-24 rounded-md sm:w-40"
@@ -17,6 +18,7 @@
           {{- (.Fill "160x120 smart").RelPermalink }} 160w,
           {{- (.Fill "320x240 smart").RelPermalink }} 2x"
           src="{{ (.Fill "160x120 smart").RelPermalink }}"
+          alt=""
         />
       </a>
     </div>


### PR DESCRIPTION
At the moment there are two lighthouse issues:
* Image (if present) doesn't have an alt tag
  * Fixed by adding a blank `alt` tag as the image is purely decorative as is described in standards
* Link has no name
  * Use the same name as the title in an `aria-label`

<img width="724" alt="Screenshot 2023-01-11 at 23 33 37" src="https://user-images.githubusercontent.com/2766321/211941227-39abb780-3659-4349-8681-f322b925ed31.png">
