### PR TITLE
Add leading-relaxed to tag list

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -2350,6 +2350,10 @@ body:has(#menu-controller:checked) {
   line-height: 1.75rem;
 }
 
+.leading-relaxed {
+  line-height: 1.625;
+}
+
 .leading-6 {
   line-height: 1.5rem;
 }

--- a/layouts/partials/article-meta.html
+++ b/layouts/partials/article-meta.html
@@ -49,7 +49,7 @@
     (and (ne $scope "single") (.Params.showTaxonomies | default (.Site.Params.list.showTaxonomies | default (.Site.Params.article.showTaxonomies | default false))))
     (and (eq $scope "single") (.Params.showTaxonomies | default (.Site.Params.article.showTaxonomies | default false)))
   }}
-    <div class="my-1 text-xs text-neutral-500 dark:text-neutral-400 ">
+    <div class="my-1 text-xs leading-relaxed text-neutral-500 dark:text-neutral-400 ">
       {{ range $taxonomy, $terms := .Site.Taxonomies }}
         {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
           {{ range $context.GetTerms $taxonomy }}


### PR DESCRIPTION
Fixes #443 

As congo uses tailwind in order to fix #443 we can use `leading-relaxed` which gives a good line-height for both width-constrained mobile as well as usual desktop layouts (below)

![image](https://user-images.githubusercontent.com/2766321/212775289-df0afbfc-d0e8-4f48-bb0b-7a3e2219c9ef.png)

![image](https://user-images.githubusercontent.com/2766321/212775393-23bc6cb2-9b9d-4521-9bf0-8fe38fe8da36.png)
