### PR TITLE
🛠 Links render hook should add `noreferrer noopener`

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,3 +1,3 @@
-<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }} {{ if or (strings.HasPrefix .Destination "http:") (strings.HasPrefix .Destination "https:") }} target="_blank"{{ end }}>
+<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }} {{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noreferrer noopener"{{ end }}>
     {{- .Text | safeHTML -}}
 </a>


### PR DESCRIPTION
According to [this](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/) and [this](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md), it is best if the links with `target="_blank"` also to have `rel="noreferrer noopener"` set to prevent any security issue.