### PR TITLE
:bug: Fix URL safety for author bio links

### DIFF
--- a/layouts/partials/author-links.html
+++ b/layouts/partials/author-links.html
@@ -5,7 +5,7 @@
         <a
           class="px-1 transition-transform hover:scale-125 hover:text-primary-700 dark:hover:text-primary-400"
           style="will-change:transform;"
-          href="{{ $url }}"
+          href="{{ $url | safeURL }}"
           target="_blank"
           aria-label="{{ $name | title }}"
           rel="me noopener noreferrer"


### PR DESCRIPTION
See https://gohugo.io/functions/safeurl/

> Without safeURL, only the URI schemes http:, https: and mailto: are considered safe by Go templates.

By piping to `safeURL`, we allow different types of links like `tel:` to work properly in author bios.

Fixes jpanther/congo#451
