### PR TITLE
🐛 Remove whitespace at EOF in render-link

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,3 +1,7 @@
-<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}"{{ end }} {{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noreferrer noopener"{{ end }}>
-    {{- .Text | safeHTML -}}
+<a
+  href="{{ .Destination | safeURL }}"
+  {{ with .Title }}title="{{ . }}"{{ end }}
+  {{ if strings.HasPrefix .Destination "http" }}target="_blank" rel="noreferrer noopener"{{ end }}
+>
+  {{- .Text | safeHTML -}}
 </a>


### PR DESCRIPTION
Removes the whitespace at the end of the file in the render-link template which incorrectly causes a blank space to be inserted after any links in the Markdown content.

Fixes #453