### PR TITLE
Fix broken link on users/index.md page + add link to arjuns.me

### DIFF
--- a/exampleSite/content/users/index.md
+++ b/exampleSite/content/users/index.md
@@ -48,7 +48,7 @@ The list below is just a handful of the websites that are built using the Congo 
 | [boyersnet.com](https://boyersnet.com)                                 | Personal site and Blog        |
 | [major.io](https://major.io)                                           | Personal site and Blog        |
 | [bayas.dev](https://bayas.dev)                                         | Personal site and Blog        |
-| [顾宇的博客](https://www.guyu.me/)                                      | Personal Blog (in Chinese)    |
+| [顾宇的博客](https://www.guyu.me/)                                       | Personal Blog (in Chinese)    |
 | [cgutierr-zgz.github.io](https://cgutierr-zgz.github.io/)              | Personal site and Tech blog   |
 | [adam.sr](https://adam.sr)                                             | Personal site and Blog        |
 | [datadi.murgi.org](https://datadi.murgi.org)                           | Personal site and Blog        |
@@ -58,5 +58,6 @@ The list below is just a handful of the websites that are built using the Congo 
 | [davidrothera.me](https://davidrothera.me)                             | Personal site and Blog        |
 | [ethantroy.com](https://ethantroy.com)                                 | Personal Site and Blog        |
 | [sug.bitprism.net](https://sug.bitprism.net)                           | Personal Site and Blog        |
+| [arjuns.me](https://arjuns.me)                                         | Personal Site and Blog        |
 
-**Congo user?** To add your site to this list, [submit a pull request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users.md).
+**Congo user?** To add your site to this list, [submit a pull request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users/index.md).


### PR DESCRIPTION
This PR includes two changes, both to the `exampleSite/content/users/index.md` file

1. It adds a link to [my site built with Congo](https://arjuns.me). (As an aside, thank you for all the hard work on this theme – it's genuinely beautiful and has been a pleasure to work with!)

2. More importantly, it fixes a broken link at the end of the file. 

It seems like a recent reorganisation shifted the file from `content/users.md`, to `content/users/index.md`. However, the link at the bottom of the file had not been updated accordingly:

```
**Congo user?** To add your site to this list, [submit a pull request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users.md).`
```

This PR changes it to:
```
**Congo user?** To add your site to this list, [submit a pull request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users/index.md).
```

Cheers!