### PR TITLE
Update GH Action snippet to deploy to GitHub Pages 

### DIFF
--- a/exampleSite/content/docs/hosting-deployment/index.md
+++ b/exampleSite/content/docs/hosting-deployment/index.md
@@ -47,6 +47,8 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write    
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
GH Action agent needs write permission to push to gh-pages branch.

Without this settings, GITHUB_TOKEN only has read permission:

<img width="627" alt="Screenshot 2023-02-28 at 22 05 52" src="https://user-images.githubusercontent.com/585764/221979623-73619ccc-4263-41fb-8efc-07337a956663.png">


after this change was made : 


<img width="539" alt="Screenshot 2023-02-28 at 22 06 19" src="https://user-images.githubusercontent.com/585764/221979737-b44e4619-364e-4927-800c-b925f49e99d3.png">

