### PR TITLE
🐛 Fix broken `srcset` links when using hugo with `--minify` option

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -24,10 +24,10 @@
             src="{{ .RelPermalink }}"
           {{ else }}
             srcset="
-            {{ (.Resize "330x").RelPermalink }} 330w,
-            {{ (.Resize "660x").RelPermalink }} 660w,
-            {{ (.Resize "1024x").RelPermalink }} 1024w,
-            {{ (.Resize "1320x").RelPermalink }} 2x"
+            {{- (.Resize "330x").RelPermalink }} 330w,
+            {{- (.Resize "660x").RelPermalink }} 660w,
+            {{- (.Resize "1024x").RelPermalink }} 1024w,
+            {{- (.Resize "1320x").RelPermalink }} 2x"
             src="{{ (.Resize "660x").RelPermalink }}"
           {{ end }}
         {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,11 +23,12 @@
               {{ if lt .Width 660 }}
                 src="{{ .RelPermalink }}"
               {{ else }}
-                srcset=" {{ (.Resize "330x").RelPermalink }} 330w,
-                {{ (.Resize "660x").RelPermalink }} 660w, {{ (.Resize "1024x").RelPermalink }}
-                1024w, {{ (.Resize "1320x").RelPermalink }} 2x"
-                src="{{ (.Resize "660x").RelPermalink }}"
-              {{ end }}
+                srcset="
+                {{- (.Resize "330x").RelPermalink }} 330w,
+                {{- (.Resize "660x").RelPermalink }} 660w,
+                {{- (.Resize "1024x").RelPermalink }} 1024w,
+                {{- (.Resize "1320x").RelPermalink }} 2x"
+            {{ end }}
             {{ end }}
             alt="{{ $.Params.featureAlt | default $.Params.coverAlt | default "" }}"
           />

--- a/layouts/partials/article-link.html
+++ b/layouts/partials/article-link.html
@@ -19,8 +19,8 @@
             sm:max-w-[10rem]" src="{{ .RelPermalink }}"
           {{ else }}
             class="w-24 rounded-md sm:w-40" srcset="
-            {{- (.Fill "160x120 smart").RelPermalink }}
-            160w, {{- (.Fill "320x240 smart").RelPermalink }} 2x"
+            {{- (.Fill "160x120 smart").RelPermalink }} 160w,
+            {{- (.Fill "320x240 smart").RelPermalink }} 2x"
             src="{{ (.Fill "160x120 smart").RelPermalink }}"
           {{ end }}
         />

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -28,10 +28,10 @@
               src="{{ .RelPermalink }}"
             {{ else }}
               srcset="
-              {{ (.Resize "330x").RelPermalink }} 330w,
-              {{ (.Resize "660x").RelPermalink }} 660w,
-              {{ (.Resize "1024x").RelPermalink }} 1024w,
-              {{ (.Resize "1320x").RelPermalink }} 2x"
+              {{- (.Resize "330x").RelPermalink }} 330w,
+              {{- (.Resize "660x").RelPermalink }} 660w,
+              {{- (.Resize "1024x").RelPermalink }} 1024w,
+              {{- (.Resize "1320x").RelPermalink }} 2x"
               src="{{ (.Resize "660x").RelPermalink }}"
             {{ end }}
           {{ end }}


### PR DESCRIPTION
HTML code generated by templates `layouts/_default/single.html` and `layouts/partials/article-link.html` caused missing space between the image link and the associated intrinsic width (e.g. `...box.jpg1024w` instead of `...box.jpg 1024w`) if hugo was used with the `--minify` option.

Also updated `layouts/_default/_markup/render-image.html` and `layouts/shortcodes/figure.html` to not cause line breaks in the srcset markup.