### PR TITLE
✨ Respect `showDate` in search results

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -140,7 +140,7 @@ function executeQuery(term) {
           <a class="flex items-center px-3 py-2 rounded-md appearance-none bg-neutral-100 dark:bg-neutral-700 focus:bg-primary-100 hover:bg-primary-100 dark:hover:bg-primary-900 dark:focus:bg-primary-900 focus:outline-dotted focus:outline-transparent focus:outline-2" href="${value.item.permalink}" tabindex="0">
             <div class="grow">
               <div class="-mb-1 text-lg font-bold">${value.item.title}</div>
-              <div class="text-sm text-neutral-500 dark:text-neutral-400">${value.item.section}<span class="px-2 text-primary-500">&middot;</span>${value.item.date}</span></div>
+              <div class="text-sm text-neutral-500 dark:text-neutral-400">${value.item.section}${value.item.date == null ? '' : `<span class="px-2 text-primary-500">&middot;</span>${value.item.date}</span>`}</div>
               <div class="text-sm italic">${value.item.summary}</div>
             </div>
             <div class="ml-2 ltr:block rtl:hidden text-neutral-500">&rarr;</div>

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,8 +1,9 @@
 {{- $index := slice -}}
 {{- range .Site.Pages -}}
   {{- $section := .Site.GetPage "section" .Section -}}
+  {{- $showDate := .Params.showDate | default .Site.Params.article.showDate -}}
   {{- $index = $index | append (dict
-    "date" (.Date | time.Format (.Site.Language.Params.dateFormat | default ":date_long")) 
+    "date" (cond (and .IsPage $showDate) (.Date | time.Format (.Site.Language.Params.dateFormat | default ":date_long")) nil)
     "title" (.Title | emojify | safeJS)
     "section" ($section.Title | emojify | safeJS)
     "summary" (.Summary | emojify | safeJS)


### PR DESCRIPTION
Also hide date for list pages, which don't have their date shown in the theme.
