### PR TITLE
author.image SmartCrop Issue

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -3,7 +3,7 @@
     {{ with .Site.Author.image }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
-        {{ $authorImage := $authorImage.Fill "192x192" }}
+        {{ $authorImage := $authorImage.Fill "192x192 Center" }}
         <img
           class="!mb-0 !mt-0 me-4 h-24 w-24 rounded-full"
           width="96"

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -7,7 +7,7 @@
     {{ with .Site.Author.image }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
-        {{ $authorImage := $authorImage.Fill "288x288" }}
+        {{ $authorImage := $authorImage.Fill "288x288 Center" }}
         <img
           class="mb-2 rounded-full h-36 w-36"
           width="144"


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
When using author.image the image seems to be cropped, then rounded. It is not CSS as the image provided is already cropped.
The problem seems to be the SmartCrop feature of Hugo #526 

The solution here is to define crop box placement explicitly: `$authorImage.Fill "192x192 Center"` 
That way, no part of an image is lost when a 1:1 image is provided.