### PR TITLE
:sparkles:Add dark mode logo option

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -17,6 +17,7 @@ enableCodeCopy = false
 [header]
   layout = "basic" # valid options: basic, hamburger, hybrid, custom
   # logo = "img/logo.jpg"
+  # darkLogo = "img/dark-logo.jpg" # specify a different logo for dark mode if needed
   showTitle = true
 
 [footer]

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -130,6 +130,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 |`robots`|_Not set_|String that indicates how robots should handle your site. If set, it will be output in the page head. Refer to [Google's docs](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) for valid values.|
 |`header.layout`|`"basic"`|The layout of the page header and menu. Valid values are `basic`, `hamburger`, `hybrid` or `custom`. When set to `custom`, you must provide your own layout by creating a `/layouts/partials/header/custom.html` file.|
 |`header.logo`|_Not set_|The relative path to the site logo file within the `assets/` folder. The logo file should be provided at 2x resolution and supports any image dimensions.|
+|`header.darkLogo`|_Not set_|As per the `header.logo` parameter, however this image is used whenever dark mode is active.|
 |`header.showTitle`|`true`|Whether the site title is displayed in the header.|
 |`footer.showCopyright`|`true`|Whether or not to show the copyright string in the site footer. Note that the string itself can be customised using the `copyright` parameter in the [languages configuration](#language-and-i18n).|
 |`footer.showThemeAttribution`|`true`|Whether or not to show the "powered by" theme attribution in the site footer. If you choose to disable this message, please consider attributing the theme somewhere else on your site (for example, on your about page).|

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,6 +1,29 @@
 {{- if .Site.Params.header.logo }}
   {{- $logo := resources.Get .Site.Params.header.logo }}
-  {{- if $logo }}
+  {{- $darkLogo := resources.Get .Site.Params.header.darkLogo }}
+
+  <!-- If both logos are present, show different logo accordingly -->
+  {{- if and $logo $darkLogo }}
+    <a href="{{ "" | relLangURL }}" class="inline mr-2 dark:hidden">
+      <img
+        src="{{ $logo.RelPermalink }}"
+        width="{{ div $logo.Width 2 }}"
+        height="{{ div $logo.Height 2 }}"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
+        alt="{{ .Site.Title }}"
+      />
+    </a>
+    <a href="{{ "" | relLangURL }}" class="hidden mr-2 dark:inline">
+      <img
+        src="{{ $darkLogo.RelPermalink }}"
+        width="{{ div $darkLogo.Width 2 }}"
+        height="{{ div $darkLogo.Height 2 }}"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
+        alt="{{ .Site.Title }}"
+      />
+    </a>
+  <!-- Else if the standard logo is present, show the logo -->
+  {{- else if $logo }}
     <a href="{{ "" | relLangURL }}" class="mr-2">
       <img
         src="{{ $logo.RelPermalink }}"


### PR DESCRIPTION
This PR adds the option to specify a dark mode logo in the `params.toml` file as mentioned in the [discussion](https://github.com/jpanther/congo/discussions/532). If no dark mode logo is specified, the default logo is used for both modes. If a dark mode logo is specified, the default logo is used for light mode and the dark mode logo is used for dark mode.

Thanks for creating such an amazing theme!