### PR TITLE
Add Dark Logo Variant Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Some `srcset` values are broken when using Hugo `--minify` option ([#508](https://github.com/jpanther/congo/pull/508))
+- Site doesn't build when using Hugo v0.112.0 ([#561](https://github.com/jpanther/congo/pull/561))
 
 ## [2.5.4] - 2023-03-20
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -17,6 +17,7 @@ enableCodeCopy = false
 [header]
   layout = "basic" # valid options: basic, hamburger, hybrid, custom
   # logo = "img/logo.jpg"
+  # darkLogo = "img/dark-logo.jpg" # specify a different logo for dark mode if needed
   showTitle = true
 
 [footer]

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -130,6 +130,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 |`robots`|_Not set_|String that indicates how robots should handle your site. If set, it will be output in the page head. Refer to [Google's docs](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) for valid values.|
 |`header.layout`|`"basic"`|The layout of the page header and menu. Valid values are `basic`, `hamburger`, `hybrid` or `custom`. When set to `custom`, you must provide your own layout by creating a `/layouts/partials/header/custom.html` file.|
 |`header.logo`|_Not set_|The relative path to the site logo file within the `assets/` folder. The logo file should be provided at 2x resolution and supports any image dimensions.|
+|`header.logoDark`|_Not set_|The relative path to the dark variant of the site logo file within the `assets/` folder. This variant is only used if the logo is set. The same recommendations as for the logo file apply. |
 |`header.showTitle`|`true`|Whether the site title is displayed in the header.|
 |`footer.showCopyright`|`true`|Whether or not to show the copyright string in the site footer. Note that the string itself can be customised using the `copyright` parameter in the [languages configuration](#language-and-i18n).|
 |`footer.showThemeAttribution`|`true`|Whether or not to show the "powered by" theme attribution in the site footer. If you choose to disable this message, please consider attributing the theme somewhere else on your site (for example, on your about page).|

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -130,6 +130,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 |`robots`|_Not set_|String that indicates how robots should handle your site. If set, it will be output in the page head. Refer to [Google's docs](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) for valid values.|
 |`header.layout`|`"basic"`|The layout of the page header and menu. Valid values are `basic`, `hamburger`, `hybrid` or `custom`. When set to `custom`, you must provide your own layout by creating a `/layouts/partials/header/custom.html` file.|
 |`header.logo`|_Not set_|The relative path to the site logo file within the `assets/` folder. The logo file should be provided at 2x resolution and supports any image dimensions.|
+|`header.darkLogo`|_Not set_|As per the `header.logo` parameter, however this image is used whenever dark mode is active.|
 |`header.showTitle`|`true`|Whether the site title is displayed in the header.|
 |`footer.showCopyright`|`true`|Whether or not to show the copyright string in the site footer. Note that the string itself can be customised using the `copyright` parameter in the [languages configuration](#language-and-i18n).|
 |`footer.showThemeAttribution`|`true`|Whether or not to show the "powered by" theme attribution in the site footer. If you choose to disable this message, please consider attributing the theme somewhere else on your site (for example, on your about page).|

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -132,7 +132,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 |`robots`|_Not set_|String that indicates how robots should handle your site. If set, it will be output in the page head. Refer to [Google's docs](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#directives) for valid values.|
 |`header.layout`|`"basic"`|The layout of the page header and menu. Valid values are `basic`, `hamburger`, `hybrid` or `custom`. When set to `custom`, you must provide your own layout by creating a `/layouts/partials/header/custom.html` file.|
 |`header.logo`|_Not set_|The relative path to the site logo file within the `assets/` folder. The logo file should be provided at 2x resolution and supports any image dimensions.|
-|`header.darkLogo`|_Not set_|As per the `header.logo` parameter, however this image is used whenever dark mode is active.|
+|`header.logoDark`|_Not set_|The relative path to the dark variant of the site logo file within the `assets/` folder. This variant is only used if the logo is set. The same recommendations as for the logo file apply. |
 |`header.showTitle`|`true`|Whether the site title is displayed in the header.|
 |`footer.showCopyright`|`true`|Whether or not to show the copyright string in the site footer. Note that the string itself can be customised using the `copyright` parameter in the [languages configuration](#language-and-i18n).|
 |`footer.showThemeAttribution`|`true`|Whether or not to show the "powered by" theme attribution in the site footer. If you choose to disable this message, please consider attributing the theme somewhere else on your site (for example, on your about page).|

--- a/layouts/partials/functions/warnings.html
+++ b/layouts/partials/functions/warnings.html
@@ -1,9 +1,9 @@
-{{ if ne .Site.Params.showAppearanceSwitcher nil }}
+{{ if ne .Params.showAppearanceSwitcher nil }}
   {{ warnf "[CONGO] Theme parameter `showAppearanceSwitcher` has been renamed to `footer.showAppearanceSwitcher`. Please update your site configuration." }}
 {{ end }}
-{{ if ne .Site.Params.showScrollToTop nil }}
+{{ if ne .Params.showScrollToTop nil }}
   {{ warnf "[CONGO] Theme parameter `showScrollToTop` has been renamed to `footer.showScrollToTop`. Please update your site configuration." }}
 {{ end }}
-{{ if ne .Site.Params.logo nil }}
+{{ if ne .Params.logo nil }}
   {{ warnf "[CONGO] Theme parameter `logo` has been renamed to `header.logo`. Please update your site configuration." }}
 {{ end }}

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,37 +1,24 @@
 {{- if .Site.Params.header.logo }}
   {{- $logo := resources.Get .Site.Params.header.logo }}
-  {{- $darkLogo := resources.Get .Site.Params.header.darkLogo }}
-
-  <!-- If both logos are present, show different logo accordingly -->
-  {{- if and $logo $darkLogo }}
-    <a href="{{ "" | relLangURL }}" class="inline mr-2 dark:hidden">
-      <img
-        src="{{ $logo.RelPermalink }}"
-        width="{{ div $logo.Width 2 }}"
-        height="{{ div $logo.Height 2 }}"
-        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
-        alt="{{ .Site.Title }}"
-      />
-    </a>
-    <a href="{{ "" | relLangURL }}" class="hidden mr-2 dark:inline">
-      <img
-        src="{{ $darkLogo.RelPermalink }}"
-        width="{{ div $darkLogo.Width 2 }}"
-        height="{{ div $darkLogo.Height 2 }}"
-        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
-        alt="{{ .Site.Title }}"
-      />
-    </a>
-  <!-- Else if the standard logo is present, show the logo -->
-  {{- else if $logo }}
+  {{- $logo_dark := resources.Get .Site.Params.header.logoDark }}
+  {{- if $logo }}
     <a href="{{ "" | relLangURL }}" class="mr-2">
       <img
         src="{{ $logo.RelPermalink }}"
         width="{{ div $logo.Width 2 }}"
         height="{{ div $logo.Height 2 }}"
-        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left{{if $logo_dark }} hidden dark:flex{{end}}"
         alt="{{ .Site.Title }}"
       />
+      {{- if $logo_dark }}
+      <img
+        src="{{ $logo_dark.RelPermalink }}"
+        width="{{ div $logo_dark.Width 2 }}"
+        height="{{ div $logo_dark.Height 2 }}"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left dark:hidden"
+        alt="{{ .Site.Title }}"
+      />
+      {{- end}}
     </a>
   {{- end }}
 {{- end }}

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,14 +1,24 @@
 {{- if .Site.Params.header.logo }}
   {{- $logo := resources.Get .Site.Params.header.logo }}
+  {{- $logo_dark := resources.Get .Site.Params.header.logoDark }}
   {{- if $logo }}
     <a href="{{ "" | relLangURL }}" class="mr-2">
       <img
         src="{{ $logo.RelPermalink }}"
         width="{{ div $logo.Width 2 }}"
         height="{{ div $logo.Height 2 }}"
-        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left{{if $logo_dark }} hidden dark:flex{{end}}"
         alt="{{ .Site.Title }}"
       />
+      {{- if $logo_dark }}
+      <img
+        src="{{ $logo_dark.RelPermalink }}"
+        width="{{ div $logo_dark.Width 2 }}"
+        height="{{ div $logo_dark.Height 2 }}"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left dark:hidden"
+        alt="{{ .Site.Title }}"
+      />
+      {{- end}}
     </a>
   {{- end }}
 {{- end }}

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,6 +1,29 @@
 {{- if .Site.Params.header.logo }}
   {{- $logo := resources.Get .Site.Params.header.logo }}
-  {{- if $logo }}
+  {{- $darkLogo := resources.Get .Site.Params.header.darkLogo }}
+
+  <!-- If both logos are present, show different logo accordingly -->
+  {{- if and $logo $darkLogo }}
+    <a href="{{ "" | relLangURL }}" class="inline mr-2 dark:hidden">
+      <img
+        src="{{ $logo.RelPermalink }}"
+        width="{{ div $logo.Width 2 }}"
+        height="{{ div $logo.Height 2 }}"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
+        alt="{{ .Site.Title }}"
+      />
+    </a>
+    <a href="{{ "" | relLangURL }}" class="hidden mr-2 dark:inline">
+      <img
+        src="{{ $darkLogo.RelPermalink }}"
+        width="{{ div $darkLogo.Width 2 }}"
+        height="{{ div $darkLogo.Height 2 }}"
+        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left"
+        alt="{{ .Site.Title }}"
+      />
+    </a>
+  <!-- Else if the standard logo is present, show the logo -->
+  {{- else if $logo }}
     <a href="{{ "" | relLangURL }}" class="mr-2">
       <img
         src="{{ $logo.RelPermalink }}"


### PR DESCRIPTION
This PR adds the possibility of defining a dark variant of the logo, such that the respective logo files are used in dark or light mode. This is especially useful when using `showAppearanceSwitcher = true` that lets the user switch between the modes.

