### PR TITLE
Hugo 0.112.0 fix

### DIFF
--- a/layouts/partials/functions/warnings.html
+++ b/layouts/partials/functions/warnings.html
@@ -1,9 +1,9 @@
-{{ if ne .Site.Params.showAppearanceSwitcher nil }}
+{{ if ne .Params.showAppearanceSwitcher nil }}
   {{ warnf "[CONGO] Theme parameter `showAppearanceSwitcher` has been renamed to `footer.showAppearanceSwitcher`. Please update your site configuration." }}
 {{ end }}
-{{ if ne .Site.Params.showScrollToTop nil }}
+{{ if ne .Params.showScrollToTop nil }}
   {{ warnf "[CONGO] Theme parameter `showScrollToTop` has been renamed to `footer.showScrollToTop`. Please update your site configuration." }}
 {{ end }}
-{{ if ne .Site.Params.logo nil }}
+{{ if ne .Params.logo nil }}
   {{ warnf "[CONGO] Theme parameter `logo` has been renamed to `header.logo`. Please update your site configuration." }}
 {{ end }}


### PR DESCRIPTION
Context in warnings.html is already `.Site`.

Fixes a build issue with Hugo 0.112.0.

Fixes #560.

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
