### PR TITLE
🛠 fix: icon padding in menus

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,9 +16,9 @@
                     <span
                       class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                     >
-                      {{ partial "icon.html" . }}
+                      {{- partial "icon.html" . -}}
                     </span>
-                  {{ end }}{{ if .Params.showName | default true }}
+                  {{- end -}}{{- if .Params.showName | default true -}}
                     <span
                       class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                       >{{ .Name | markdownify | emojify }}</span
@@ -55,9 +55,9 @@
                   <span
                     class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                   >
-                    {{ partial "icon.html" . }}
+                    {{- partial "icon.html" . -}}
                   </span>
-                {{ end }}{{ if .Params.showName | default true }}
+                {{- end -}}{{- if .Params.showName | default true -}}
                   <span
                     class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                     >{{ .Name | markdownify | emojify }}</span

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -22,9 +22,9 @@
                       <span
                         class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                       >
-                        {{ partial "icon.html" . }}
+                        {{- partial "icon.html" . -}}
                       </span>
-                    {{ end }}{{ if .Params.showName | default true }}
+                    {{- end -}}{{- if .Params.showName | default true -}}
                       <span
                         class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                         >{{ .Name | markdownify | emojify }}</span
@@ -44,9 +44,9 @@
                     title="{{ i18n "footer.dark_appearance" }}"
                   >
                     {{ with .Params.icon | default "moon" }}
-                      {{ partial "icon.html" . }}
-                    {{ end }}
-                    {{ if .Params.showName | default true }}
+                      {{- partial "icon.html" . -}}
+                    {{- end -}}
+                    {{- if .Params.showName | default true -}}
                       <span
                         class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                         >{{ .Name | markdownify | emojify }}</span
@@ -77,9 +77,9 @@
                     <span
                       class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                     >
-                      {{ partial "icon.html" . }}
+                      {{- partial "icon.html" . -}}
                     </span>
-                  {{ end }}{{ if .Params.showName | default true }}
+                  {{- end -}}{{- if .Params.showName | default true -}}
                     <span
                       class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                       >{{ .Name | markdownify | emojify }}</span

--- a/layouts/partials/header/hamburger.html
+++ b/layouts/partials/header/hamburger.html
@@ -38,9 +38,9 @@
                           <span
                             class="transition-colors group-dark:hover:text-primary-400 group-hover:text-primary-600"
                           >
-                            {{ partial "icon.html" . }}
+                            {{- partial "icon.html" . -}}
                           </span>
-                        {{ end }}{{ if .Params.showName | default true }}
+                        {{- end -}}{{- if .Params.showName | default true -}}
                           <span
                             class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                             >{{ .Name | markdownify | emojify }}</span
@@ -60,9 +60,9 @@
                         title="{{ i18n "footer.dark_appearance" }}"
                       >
                         {{ with .Params.icon | default "moon" }}
-                          {{ partial "icon.html" . }}
-                        {{ end }}
-                        {{ if .Params.showName | default true }}
+                          {{- partial "icon.html" . -}}
+                        {{- end -}}
+                        {{- if .Params.showName | default true -}}
                           <span
                             class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                             >{{ .Name | markdownify | emojify }}</span
@@ -74,9 +74,9 @@
                         title="{{ i18n "footer.light_appearance" }}"
                       >
                         {{ with .Params.icon | default "sun" }}
-                          {{ partial "icon.html" . }}
-                        {{ end }}
-                        {{ if .Params.showName | default true }}
+                          {{- partial "icon.html" . -}}
+                        {{- end -}}
+                        {{- if .Params.showName | default true -}}
                           <span
                             class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                             >{{ .Name | markdownify | emojify }}</span
@@ -93,9 +93,9 @@
                         <span
                           class="transition-colors group-dark:hover:text-primary-400 group-hover:text-primary-600"
                         >
-                          {{ partial "icon.html" . }}
+                          {{- partial "icon.html" . -}}
                         </span>
-                      {{ end }}{{ if .Params.showName | default true }}
+                      {{- end -}}{{- if .Params.showName | default true -}}
                         <span
                           class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                           >{{ .Name | markdownify | emojify }}</span

--- a/layouts/partials/header/hybrid.html
+++ b/layouts/partials/header/hybrid.html
@@ -38,9 +38,9 @@
                           <span
                             class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                           >
-                            {{ partial "icon.html" . }}
+                            {{- partial "icon.html" . -}}
                           </span>
-                        {{ end }}{{ if .Params.showName | default true }}
+                        {{- end -}}{{- if .Params.showName | default true -}}
                           <span
                             class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                             >{{ .Name | markdownify | emojify }}</span
@@ -60,9 +60,9 @@
                         title="{{ i18n "footer.dark_appearance" }}"
                       >
                         {{ with .Params.icon | default "moon" }}
-                          {{ partial "icon.html" . }}
-                        {{ end }}
-                        {{ if .Params.showName | default true }}
+                          {{- partial "icon.html" . -}}
+                        {{- end -}}
+                        {{- if .Params.showName | default true -}}
                           <span
                             class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                             >{{ .Name | markdownify | emojify }}</span
@@ -74,9 +74,9 @@
                         title="{{ i18n "footer.light_appearance" }}"
                       >
                         {{ with .Params.icon | default "sun" }}
-                          {{ partial "icon.html" . }}
-                        {{ end }}
-                        {{ if .Params.showName | default true }}
+                          {{- partial "icon.html" . -}}
+                        {{- end -}}
+                        {{- if .Params.showName | default true -}}
                           <span
                             class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                             >{{ .Name | markdownify | emojify }}</span
@@ -93,9 +93,9 @@
                         <span
                           class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                         >
-                          {{ partial "icon.html" . }}
+                          {{- partial "icon.html" . -}}
                         </span>
-                      {{ end }}{{ if .Params.showName | default true }}
+                      {{- end -}}{{- if .Params.showName | default true -}}
                         <span
                           class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                           >{{ .Name | markdownify | emojify }}</span
@@ -136,9 +136,9 @@
                       <span
                         class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                       >
-                        {{ partial "icon.html" . }}
+                        {{- partial "icon.html" . -}}
                       </span>
-                    {{ end }}{{ if .Params.showName | default true }}
+                    {{- end -}}{{- if .Params.showName | default true -}}
                       <span
                         class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                         >{{ .Name | markdownify | emojify }}</span
@@ -158,9 +158,9 @@
                     title="{{ i18n "footer.dark_appearance" }}"
                   >
                     {{ with .Params.icon | default "moon" }}
-                      {{ partial "icon.html" . }}
-                    {{ end }}
-                    {{ if .Params.showName | default true }}
+                      {{- partial "icon.html" . -}}
+                    {{- end -}}
+                    {{- if .Params.showName | default true -}}
                       <span
                         class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                         >{{ .Name | markdownify | emojify }}</span
@@ -172,9 +172,9 @@
                     title="{{ i18n "footer.light_appearance" }}"
                   >
                     {{ with .Params.icon | default "sun" }}
-                      {{ partial "icon.html" . }}
-                    {{ end }}
-                    {{ if .Params.showName | default true }}
+                      {{- partial "icon.html" . -}}
+                    {{- end -}}
+                    {{- if .Params.showName | default true -}}
                       <span
                         class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                         >{{ .Name | markdownify | emojify }}</span
@@ -191,9 +191,9 @@
                     <span
                       class="group-dark:hover:text-primary-400 transition-colors group-hover:text-primary-600"
                     >
-                      {{ partial "icon.html" . }}
+                      {{- partial "icon.html" . -}}
                     </span>
-                  {{ end }}{{ if .Params.showName | default true }}
+                  {{- end -}}{{- if .Params.showName | default true -}}
                     <span
                       class="decoration-primary-500 group-hover:underline group-hover:decoration-2 group-hover:underline-offset-2"
                       >{{ .Name | markdownify | emojify }}</span

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,6 +1,6 @@
-{{ $icon := resources.Get (print "icons/" . ".svg") }}
-{{ if $icon }}
-  <span class="relative inline-block align-text-bottom icon">
-    {{ $icon.Content | safeHTML }}
+{{- $icon := resources.Get (print "icons/" . ".svg") -}}
+{{- if $icon -}}
+  <span class="relative inline-block align-text-bottom px-1 icon">
+    {{- $icon.Content | safeHTML -}}
   </span>
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
The menu items with icons currently have a small spacing between the icon and the text, which is nice. However, the spacing exists because the rendered HTML has much spacing between the `<span>`s element, and this spacing will disappear when passing the `--minify` flag to `hugo serve` or `hugo build` commands, causing the icon to stick close to the text.

For example, see tomy0000000/blog#8

This PR removes all arbitrary spacing and adds a px-1 class to state the spacing explicitly.
