### PR TITLE
🩹 Update page source URL

### DIFF
--- a/exampleSite/content/samples/charts/index.md
+++ b/exampleSite/content/samples/charts/index.md
@@ -10,7 +10,7 @@ Congo includes support for Chart.js using the `chart` shortcode. Simply wrap the
 
 Refer to the [chart shortcode]({{< ref "docs/shortcodes#chart" >}}) docs for more details.
 
-The examples below are a small selection taken from the [official Chart.js docs](https://www.chartjs.org/docs/latest/samples). You can also [view the page source](https://raw.githubusercontent.com/jpanther/congo/dev/exampleSite/content/samples/charts.md) on GitHub to see the markup.
+The examples below are a small selection taken from the [official Chart.js docs](https://www.chartjs.org/docs/latest/samples). You can also [view the page source](https://raw.githubusercontent.com/jpanther/congo/dev/exampleSite/content/samples/charts/index.md) on GitHub to see the markup.
 
 ## Bar chart
 

--- a/exampleSite/content/samples/diagrams-flowcharts/index.md
+++ b/exampleSite/content/samples/diagrams-flowcharts/index.md
@@ -10,7 +10,7 @@ Mermaid diagrams are supported in Congo using the `mermaid` shortcode. Simply wr
 
 Refer to the [mermaid shortcode]({{< ref "docs/shortcodes#mermaid" >}}) docs for more details.
 
-The examples below are a small selection taken from the [official Mermaid docs](https://mermaid-js.github.io/mermaid/). You can also [view the page source](https://raw.githubusercontent.com/jpanther/congo/dev/exampleSite/content/samples/diagrams-flowcharts.md) on GitHub to see the markup.
+The examples below are a small selection taken from the [official Mermaid docs](https://mermaid-js.github.io/mermaid/). You can also [view the page source](https://raw.githubusercontent.com/jpanther/congo/dev/exampleSite/content/samples/diagrams-flowcharts/index.md) on GitHub to see the markup.
 
 ## Flowchart
 


### PR DESCRIPTION
On the Charts and Diagrams pages the links to view the source code are outdated. So modify the URLs to match the current state of the project.

Btw: sorry for the spam 😅.