### PR TITLE
Use correct render value in external archetype

### DIFF
--- a/archetypes/external.md
+++ b/archetypes/external.md
@@ -5,6 +5,5 @@ externalUrl: ""
 summary: ""
 showReadingTime: false
 _build:
-  render: "false"
-  list: "local"
+  render: "never"
 ---


### PR DESCRIPTION
On hugo documentation render params should have value "render" not "false".
Also removed the list param to allow external to be shown in homepage.
