### PR TITLE
Provide width and height for images

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -28,6 +28,8 @@
         {{ if eq .MediaType.SubType "svg" }}
           src="{{ .RelPermalink }}"
         {{ else }}
+          width="{{ .Width }}"
+          height="{{ .Height }}"
           {{ if lt .Width 660 }}
             src="{{ .RelPermalink }}"
           {{ else }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,6 +20,8 @@
             {{ if eq .MediaType.SubType "svg" }}
               src="{{ .RelPermalink }}"
             {{ else }}
+              width="{{ .Width }}"
+              height="{{ .Height }}"
               {{ if lt .Width 660 }}
                 src="{{ .RelPermalink }}"
               {{ else }}

--- a/layouts/partials/article-link.html
+++ b/layouts/partials/article-link.html
@@ -22,6 +22,8 @@
             {{- (.Fill "160x120 smart").RelPermalink }}
             160w, {{- (.Fill "320x240 smart").RelPermalink }} 2x"
             src="{{ (.Fill "160x120 smart").RelPermalink }}"
+            width="160"
+            height="120"
           {{ end }}
           {{ if $.Site.Params.enableImageLazyLoading | default true }}
             loading="lazy"

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -27,6 +27,8 @@
           {{ if eq .MediaType.SubType "svg" }}
             src="{{ .RelPermalink }}"
           {{ else }}
+            width="{{ .Width }}"
+            height="{{ .Height }}"
             {{ if lt .Width 660 }}
               src="{{ .RelPermalink }}"
             {{ else }}


### PR DESCRIPTION
Provide `width` and `height` for images to reduce [layout shift](https://web.dev/cls/).

As proposed here https://github.com/jpanther/congo/discussions/644