### PR TITLE
Applied capo recommendations

### DIFF
--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -4,6 +4,7 @@
 
 theme = "congo"
 defaultContentLanguage = "en"
+disableHugoGeneratorInject = true
 
 enableRobotsTXT = true
 paginate = 15

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,11 +1,6 @@
 <head>
   <meta charset="utf-8" />
-  {{ with site.Params.htmlCode | default .Site.LanguageCode }}
-    <meta http-equiv="content-language" content="{{ . }}" />
-  {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="rgb(255,255,255)" />
-  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
   {{/* Title */}}
   {{ if .IsHome -}}
     <title>{{ .Site.Title | emojify }}</title>
@@ -14,21 +9,6 @@
     <title>{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}</title>
     <meta name="title" content="{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}" />
   {{- end }}
-  {{/* Metadata */}}
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
-  {{ with union .Site.Params.keywords .Params.keywords -}}
-    <meta name="keywords" content="{{ delimit . `, `}}" />
-  {{- end }}
-  {{ with .Site.Params.robots }}
-    <meta name="robots" content="{{ . }}" />
-  {{ end }}
-  {{ with .Params.robots }}
-    <meta name="robots" content="{{ . }}" />
-  {{ end }}
-  <link rel="canonical" href="{{ .Permalink }}" />
-  {{ range .AlternativeOutputFormats -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink ($.Site.Title | emojify) | safeHTML }}
-  {{ end -}}
   {{/* Asset bundles */}}
   {{ $assets := newScratch }}
   {{ $algorithm := .Site.Params.fingerprintAlgorithm | default "sha256" }}
@@ -70,6 +50,34 @@
     {{ $bundleJS := $assets.Get "js" | resources.Concat "js/main.bundle.js" | resources.Minify | resources.Fingerprint $algorithm }}
     <script defer type="text/javascript" id="script-bundle" src="{{ $bundleJS.RelPermalink }}" integrity="{{ $bundleJS.Data.Integrity }}" data-copy="{{ i18n "code.copy" }}" data-copied="{{ i18n "code.copied" }}"></script>
   {{ end }}
+  {{/* Vendor */}}
+  {{ partial "vendor.html" . }}
+  {{/* Analytics */}}
+  {{ partial "analytics.html" . }}
+  {{/* Extend head - eg. for custom analytics scripts, etc. */}}
+  {{ if templates.Exists "partials/extend-head.html" }}
+    {{ partial "extend-head.html" .Site }}
+  {{ end }}
+  {{ with site.Params.htmlCode | default .Site.LanguageCode }}
+  <meta http-equiv="content-language" content="{{ . }}" />
+  {{ end }}
+  <meta name="theme-color" content="rgb(255,255,255)" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  {{/* Metadata */}}
+  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
+  {{ with union .Site.Params.keywords .Params.keywords -}}
+    <meta name="keywords" content="{{ delimit . `, `}}" />
+  {{- end }}
+  {{ with .Site.Params.robots }}
+    <meta name="robots" content="{{ . }}" />
+  {{ end }}
+  {{ with .Params.robots }}
+    <meta name="robots" content="{{ . }}" />
+  {{ end }}
+  <link rel="canonical" href="{{ .Permalink }}" />
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink ($.Site.Title | emojify) | safeHTML }}
+  {{ end -}}
   {{/* Icons */}}
   {{ if templates.Exists "partials/favicons.html" }}
     {{ partialCached "favicons.html" .Site }}
@@ -103,13 +111,5 @@
     {{ range $links := . }}
       {{ range $name, $url := $links }}<link href="{{ $url }}" rel="me" />{{ end }}
     {{ end }}
-  {{ end }}
-  {{/* Vendor */}}
-  {{ partial "vendor.html" . }}
-  {{/* Analytics */}}
-  {{ partial "analytics.html" . }}
-  {{/* Extend head - eg. for custom analytics scripts, etc. */}}
-  {{ if templates.Exists "partials/extend-head.html" }}
-    {{ partial "extend-head.html" .Site }}
   {{ end }}
 </head>


### PR DESCRIPTION
**Matter of taste**. I understand if you don't want to mess up with source-code in order to obey Capo recommendations

---

Applied capo recommendations, as proposed here https://github.com/jpanther/congo/discussions/644

Before:
<img width="820" alt="Screenshot 2023-09-11 at 11 08 16" src="https://github.com/jpanther/congo/assets/179534/60d29cbb-e62e-43a8-9276-9aff7e6db4b1">

After:
<img width="825" alt="Screenshot 2023-09-11 at 11 11 42" src="https://github.com/jpanther/congo/assets/179534/d71d979c-bb88-427e-a50a-e5a938ebd2fe">
