### PR TITLE
Fixed taxonomies display issue

### DIFF
--- a/layouts/partials/article-meta.html
+++ b/layouts/partials/article-meta.html
@@ -50,13 +50,13 @@
     (and (ne $scope "single") (.Params.showTaxonomies | default (.Site.Params.list.showTaxonomies | default (.Site.Params.article.showTaxonomies | default false))))
     (and (eq $scope "single") (.Params.showTaxonomies | default (.Site.Params.article.showTaxonomies | default false)))
   }}
-    <div class="my-1 text-xs leading-relaxed text-neutral-500 dark:text-neutral-400 ">
+    <div class="flex flex-wrap my-1 text-xs leading-relaxed text-neutral-500 dark:text-neutral-400 ">
       {{ range $taxonomy, $terms := .Site.Taxonomies }}
         {{ if (gt (len ($context.GetTerms $taxonomy)) 0) }}
           {{ range $context.GetTerms $taxonomy }}
             <a
               href="{{ .RelPermalink }}"
-              class="rounded-md border border-neutral-200 px-1 py-[1px] hover:border-primary-300 hover:text-primary-700 dark:border-neutral-600 dark:hover:border-primary-600 dark:hover:text-primary-400"
+              class="mx-1 my-1 rounded-md border border-neutral-200 px-1 py-[1px] hover:border-primary-300 hover:text-primary-700 dark:border-neutral-600 dark:hover:border-primary-600 dark:hover:text-primary-400"
               >{{ .LinkTitle }}</a
             >
           {{ end }}


### PR DESCRIPTION
When there are a lot of tags for the article they begin to be carried to the next line that cause some styling issues. Here is an example:
![Before](https://github.com/jpanther/congo/assets/107808742/d24f02a0-7432-4d77-9eca-6af556924eeb)

I suggest to make them look little bit better:
![After](https://github.com/jpanther/congo/assets/107808742/965fb8bd-3ac2-4648-a279-83c848776dfb)

There is a real example of this issue occurrence as well. It happened for the [article ](https://ruby.mobidev.biz/posts/faq-chatbot/) in the our developers team`s blog.