### PR TITLE
:children_crossing: :adhesive_bandage: [SVG_Support: Logo Image] 

### DIFF
--- a/layouts/partials/functions/warnings.html
+++ b/layouts/partials/functions/warnings.html
@@ -7,3 +7,6 @@
 {{ if ne .Params.logo nil }}
   {{ warnf "[CONGO] Theme parameter `logo` has been renamed to `header.logo`. Please update your site configuration." }}
 {{ end }}
+{{ if eq .Params.header.logo .Params.header.logo_dark }}
+  {{-  warnf "[CONGO] Interactions with a single resource via multiple distinct resource handles can be problematic. It is recommended to only declare `header.logo_dark` when it is distinct from `header.logo`." }}
+{{- end }}

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -5,17 +5,29 @@
     <a href="{{ "" | relLangURL }}" class="mr-2">
       <img
         src="{{ $logo.RelPermalink }}"
-        width="{{ div $logo.Width 2 }}"
-        height="{{ div $logo.Height 2 }}"
-        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left{{ if $logo_dark }} hidden dark:flex{{ end }}"
+        {{- if eq $logo.MediaType.SubType "svg" }}
+          width="25"
+          height="25"
+          class="m-0 p-0 object-scale-down object-left{{ if $logo_dark }} hidden dark:flex{{ end }}"
+        {{- else }}  
+          width="{{ div $logo.Width 2 }}"
+          height="{{ div $logo.Height 2 }}"
+          class="max-h-[10rem] max-w-[10rem] object-scale-down object-left{{ if $logo_dark }} hidden dark:flex{{ end }}"
+        {{- end }}  
         alt="{{ .Site.Title }}"
       />
       {{- if $logo_dark }}
       <img
         src="{{ $logo_dark.RelPermalink }}"
-        width="{{ div $logo_dark.Width 2 }}"
-        height="{{ div $logo_dark.Height 2 }}"
-        class="max-h-[10rem] max-w-[10rem] object-scale-down object-left dark:hidden"
+        {{- if eq $logo_dark.MediaType.SubType "svg" }}
+          width="25"
+          height="25"
+          class="m-0 p-0 object-scale-down object-left{{ if $logo }} !dark:hidden{{ end }}"
+        {{- else }}
+          width="{{ div $logo_dark.Width 2 }}"
+          height="{{ div $logo_dark.Height 2 }}"
+          class="max-h-[10rem] max-w-[10rem] object-scale-down object-left{{ if $logo }} !dark:hidden{{ end }}"
+        {{- end }}
         alt="{{ .Site.Title }}"
       />
       {{- end}}


### PR DESCRIPTION
Add logic brace around img dimension math, so as to support SVGs. 

Add warning discouraging specifying the same asset as both logo and logo_dark.
