### PR TITLE
:children_crossing: :adhesive_bandage: SVG support for author's image

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -3,7 +3,9 @@
     {{ with .Site.Author.image }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
-        {{ $authorImage := $authorImage.Fill "192x192 Center" }}
+        {{- if ne $authorImage.MediaType.SubType "svg" }}
+          {{ $authorImage := $authorImage.Fill "192x192 Center" }}
+        {{- end }}
         <img
           class="!mb-0 !mt-0 me-4 h-24 w-24 rounded-full"
           width="96"

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -7,7 +7,9 @@
     {{ with .Site.Author.image }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
-        {{ $authorImage := $authorImage.Fill "288x288 Center" }}
+        {{- if  ne $authorImage.MediaType.SubType "svg" }}
+          {{ $authorImage := $authorImage.Fill "288x288 Center" }}
+        {{- end }}
         <img
           class="mb-2 h-36 w-36 rounded-full"
           width="144"


### PR DESCRIPTION
sidestep image resizing operations when using a vector image for the author's image.. Pretty straight forward.

I didn't see anyplace else that these images are in use. 
Did I miss anything?

![single-brk](https://github.com/jpanther/congo/assets/1680659/51ba48e5-18d7-4949-b068-84817c893a18)
![single-en](https://github.com/jpanther/congo/assets/1680659/fbefd614-fa28-482b-9f3a-e5593c27f9da)
![Homepage-Profile-en](https://github.com/jpanther/congo/assets/1680659/d87a46a5-ddb5-4a84-b97d-c9c5883a7d3b)
![homepage-profile-BRK](https://github.com/jpanther/congo/assets/1680659/dab6434e-f9a5-429c-a014-b411735cc7e7)
