### PR TITLE
Print warning if system can't resolve link to a markdown file

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -2,10 +2,16 @@
 {{ $isRemote := strings.HasPrefix $link "http" }}
 {{- if not $isRemote }}
   {{ $url := urls.Parse .Destination }}
-  {{ if $url.Path }}
+  {{- if $url.Path }}
     {{ $fragment := "" }}
     {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
-    {{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end -}}
-  {{ end }}
+    {{- with .Page.GetPage $url.Path }}
+      {{ $link = printf "%s%s" .RelPermalink $fragment }}
+    {{ else }}
+      {{- if hasSuffix $url.Path ".md" }}
+        {{ warnf "Can't resolve: %s" .Destination }}
+      {{ end -}}
+    {{ end -}}
+  {{ end -}}
 {{ end -}}
 <a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank" rel="noreferrer"{{ end }}>{{- .Text | safeHTML -}}</a>


### PR DESCRIPTION
Small improvement:

if user uses link, like `[post](/content/posts/other-post.md)` and this file doesn't exist (e.g. broken link), Hugo will print a warning. Which is nice way to prevent 404 errors