### PR TITLE
🛠 fix: Empty block when locale switcher is hidden (#678)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     <nav class="pb-4 text-base font-medium text-neutral-500 dark:text-neutral-400">
       <ul class="flex flex-col list-none sm:flex-row">
         {{ range .Site.Menus.footer }}
-          {{ if and (eq .Params.action "locale") (and (not page.IsTranslated) (not site.IsMultiLingual)) }}
+          {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
             {{ continue }}
           {{ end }}
           <li class="mb-1 group text-end sm:mb-0 sm:me-7 sm:last:me-0">

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -9,7 +9,7 @@
       <ul class="flex flex-col list-none text-end sm:flex-row">
         {{ if .Site.Menus.main }}
           {{ range .Site.Menus.main }}
-            {{ if and (eq .Params.action "locale") (and (not page.IsTranslated) (not site.IsMultiLingual)) }}
+            {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
               {{ continue }}
             {{ end }}
             <li class="group mb-1 sm:mb-0 sm:me-7 sm:last:me-0.5">

--- a/layouts/partials/header/hamburger.html
+++ b/layouts/partials/header/hamburger.html
@@ -25,7 +25,7 @@
             </li>
             {{ if .Site.Menus.main }}
               {{ range .Site.Menus.main }}
-                {{ if and (eq .Params.action "locale") (and (not page.IsTranslated) (not site.IsMultiLingual)) }}
+                {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
                   {{ continue }}
                 {{ end }}
                 <li class="mb-1 group">

--- a/layouts/partials/header/hybrid.html
+++ b/layouts/partials/header/hybrid.html
@@ -25,7 +25,7 @@
             </li>
             {{ if .Site.Menus.main }}
               {{ range .Site.Menus.main }}
-                {{ if and (eq .Params.action "locale") (and (not page.IsTranslated) (not site.IsMultiLingual)) }}
+                {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
                   {{ continue }}
                 {{ end }}
                 <li class="mb-1 group">
@@ -129,7 +129,7 @@
       <ul class="flex-row hidden list-none text-end sm:flex">
         {{ if .Site.Menus.main }}
           {{ range .Site.Menus.main }}
-            {{ if and (eq .Params.action "locale") (and (not page.IsTranslated) (not site.IsMultiLingual)) }}
+            {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
               {{ continue }}
             {{ end }}
             <li class="mb-1 group sm:mb-0 sm:me-7 sm:last:me-0">


### PR DESCRIPTION
Minor fix for #678