### PR TITLE
:recycle: Render author image with picture partial

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -4,7 +4,6 @@
     {{ $lazy := .Params.enableImageLazyLoading|default  .Site.Params.enableImageLazyLoading | default true }}
     {{ $altText := ($.Site.Language.Params.Author.name | default "Author") }}
     {{ with .Site.Language.Params.Author.image }}
-      {{- warnf "called. AuthorImage %s should be shown."  . }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
         {{ $imgClass := "!mb-0 !mt-0 me-4 w-24 h-auto rounded-full" }}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,19 +1,14 @@
 {{ if .Params.showAuthor | default (.Site.Params.article.showAuthor | default true) }}
+{{- warnf "%s called. Author %s should be shown." .Page.File .Site.Language.Params.Author.name }}
   <div class="flex">
+    {{ $lazy := .Params.enableImageLazyLoading|default  .Site.Params.enableImageLazyLoading | default true }}
+    {{ $altText := ($.Site.Language.Params.Author.name | default "Author") }}
     {{ with .Site.Language.Params.Author.image }}
+      {{- warnf "called. AuthorImage %s should be shown."  . }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
-        {{ $authorImage := $authorImage.Fill "192x192 Center" }}
-        <img
-          class="!mb-0 !mt-0 me-4 h-24 w-24 rounded-full"
-          width="96"
-          height="96"
-          alt="{{ $.Site.Language.Params.Author.name | default "Author" }}"
-          src="{{ $authorImage.RelPermalink }}"
-          {{ if $.Site.Params.enableImageLazyLoading | default true }}
-            loading="lazy"
-          {{ end }}
-        />
+        {{ $imgClass := "!mb-0 !mt-0 me-4 w-24 h-auto rounded-full" }}
+        {{ partial "picture.html" (dict "img" $authorImage "alt" $altText "class" $imgClass "lazy" $lazy  ) }}
       {{ end }}
     {{ end }}
     <div class="place-self-center">

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,5 +1,4 @@
 {{ if .Params.showAuthor | default (.Site.Params.article.showAuthor | default true) }}
-{{- warnf "%s called. Author %s should be shown." .Page.File .Site.Language.Params.Author.name }}
   <div class="flex">
     {{ $lazy := .Params.enableImageLazyLoading|default  .Site.Params.enableImageLazyLoading | default true }}
     {{ $altText := ($.Site.Language.Params.Author.name | default "Author") }}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -4,17 +4,13 @@
   {{ end }} flex flex-col items-center justify-center text-center"
 >
   <header class="mb-3 flex flex-col items-center">
+    {{ $lazy := .Params.enableImageLazyLoading | default .Site.Params.enableImageLazyLoading | default true }}
+    {{ $altText := ($.Site.Language.Params.Author.name | default "Author") }}
     {{ with .Site.Language.Params.Author.image }}
       {{ $authorImage := resources.Get . }}
       {{ if $authorImage }}
-        {{ $authorImage := $authorImage.Fill "288x288 Center" }}
-        <img
-          class="mb-2 h-36 w-36 rounded-full"
-          width="144"
-          height="144"
-          alt="{{ $.Site.Language.Params.Author.name | default "Author" }}"
-          src="{{ $authorImage.RelPermalink }}"
-        />
+        {{ $imgClass := "mb-2 h-auto w-36 rounded-full" }}
+        {{ partial "picture.html" (dict "img" $authorImage "alt" $altText "class" $imgClass "lazy" $lazy) }}
       {{ end }}
     {{ end }}
     <h1 class="text-4xl font-extrabold">


### PR DESCRIPTION
in lieu of #687 This uses the picture partial image rendering path to generate the author content.
Screens included to show SVG working.

An interesting behavior manifests if the width and height classes are the same in `layouts/partials/author.html`:

(screens included to illustrate the problem)

What seems to be the "best" way forward is to specify w explicity, and set H to `auto`
![congoAuthorPicture-SVG-AuthoredPage](https://github.com/jpanther/congo/assets/1680659/17d95cf8-8002-4837-b41b-ac3f71d9e601)
![congoAuthorPicture-SVG-Profile](https://github.com/jpanther/congo/assets/1680659/f8950a16-6a34-494f-9733-647277de03e1)
![congoAuthorPicture-w-Hauto2](https://github.com/jpanther/congo/assets/1680659/c1ab23d9-dcfa-4385-8425-7f67f38431a2)
![congoAuthorPicture-w-Hauto](https://github.com/jpanther/congo/assets/1680659/8668e4b5-9fd4-45fe-ab8f-54daacd22b6f)
![congoAuthorPicture-h+w](https://github.com/jpanther/congo/assets/1680659/03f3efbc-ef41-4425-916a-2c9be98dcef4)
![congoAuthorPicture-hOnly](https://github.com/jpanther/congo/assets/1680659/b0a66d82-5fd8-4b40-b1f6-5c6c491c6aaf)
![congoAuthorPicture-wOnly](https://github.com/jpanther/congo/assets/1680659/9c7fc4e5-ae3f-4fdc-b8a8-b58063f6dffb)
![congoAuthorPicture-auto](https://github.com/jpanther/congo/assets/1680659/41affd58-4236-4752-8194-a4dcb4687e14)
