### PR TITLE
Added Japanese localization for sharing to the Mastodon.

### DIFF
--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -47,7 +47,7 @@ sharing:
   email: " Eメールを送る"
   facebook: "Facebookでシェアする"
   linkedin: "LinkedInでシェアする"
-  # mastodon: "Toot on Mastodon"
+  mastodon: "Mastodonに投稿する"
   pinterest: "Pinterestでピンする"
   reddit: "Redditに投稿する"
   twitter: "Twitterに投稿する"


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->

- Translated and enabled the previously commented-out `mastodon: "Toot on Mastodon"` in `i18n/ja.yaml`.
- Ran `npm run example` and confirmed that the Tooltip is localized in Japanese, as shown in the image below.
- If there are no problems, I would appreciate it if you could merge it into the dev branch.

![スクリーンショット 2023-12-17 11 48 02](https://github.com/jpanther/congo/assets/5867126/ede38eee-5d05-450b-a97d-de240b3edabe)
