### PR TITLE
🐛 Add CSS overflow/wrapping on KaTeX, tables, and code sections

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -1231,6 +1231,28 @@ body:has(#menu-controller:checked) {
   opacity: 0.05;
 }
 
+/* Fix long KaTeX equations on mobile (see https://katex.org/docs/issues.html#css-customization) */
+
+.katex-display {
+  overflow: auto hidden
+}
+
+/* Fix long tables breaking out of article on mobile */
+
+table {
+  display: block;
+  overflow: auto;
+}
+
+/* Fix long inline code sections breaking out of article on mobile */
+
+code {
+  word-wrap: break-word;
+  /* All browsers since IE 5.5+ */
+  overflow-wrap: break-word;
+  /* Renamed property in CSS3 draft spec */
+}
+
 /* -- Chroma Highlight -- */
 
 /* Background */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -96,6 +96,21 @@ body:has(#menu-controller:checked) {
   @apply absolute -z-10 opacity-5;
 }
 
+/* Fix long KaTeX equations on mobile (see https://katex.org/docs/issues.html#css-customization) */
+.katex-display { overflow: auto hidden }
+
+/* Fix long tables breaking out of article on mobile */
+table {
+    display: block;
+    overflow: auto;
+}
+
+/* Fix long inline code sections breaking out of article on mobile */
+code {
+    word-wrap: break-word;         /* All browsers since IE 5.5+ */
+    overflow-wrap: break-word;     /* Renamed property in CSS3 draft spec */
+}
+
 /* -- Chroma Highlight -- */
 /* Background */
 .chroma {


### PR DESCRIPTION
(Upstreaming changes from https://github.com/nunocoracao/blowfish/pull/1129)

This fixes a few bugs where long post elements could break out of the width of the overall page and break overall formatting or views, especially on mobile devices. The corresponding edits to `assets/css/compiled/main.css` are from the Tailwind compiler.

Note that the scroll bars on these elements will fade in and out as needed, depending on the default behavior of the user's browser.
![congo-breaking-site-width-comparison](https://github.com/jpanther/congo/assets/14023456/9ab40a26-196c-4b21-b4c2-5877e838c3c3)
