### PR TITLE
🐛 update labeller to use v5 config

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -1,6 +1,7 @@
 i18n:
-  - i18n/*
+- changed-files:
+  - any-glob-to-any-file: i18n/*
 
-documentation:
-  - "*.md"
-  - exampleSite/content/*
+Documentation:
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -2,6 +2,6 @@ i18n:
 - changed-files:
   - any-glob-to-any-file: i18n/*
 
-Documentation:
+documentation:
 - changed-files:
   - any-glob-to-any-file: '**/*.md'


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->

- [x] fix: fix labeller ci failing

CI will fail until this is merged to `dev` branch.

Test:
- Main Repo: https://github.com/Jh123x/congo (With the labeller config change)
- MR used to test: https://github.com/Jh123x/congo/pull/2 (Merging to a branch with labeller change)
- Same MR here: https://github.com/jpanther/congo/pull/755 (but fails labeller ci)

Please let me know if there are any other changes to the config required.