### PR TITLE
remove unneccessary ß in single.html

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,6 @@
       <div class="mb-12 mt-8 text-base text-neutral-500 print:hidden dark:text-neutral-400">
         {{ partial "article-meta.html" (dict "context" . "scope" "single") }}
       </div>
-      ß
       {{ with $feature }}
         <div class="prose">
           {{ $altText := $.Params.featureAlt | default $.Params.coverAlt | default "" }}


### PR DESCRIPTION
This PR removes an unnecessary ß in the single.html introduced in the latest upgrade of tailwind.

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
