### PR TITLE
Add jnsgr.uk to list of users

### DIFF
--- a/exampleSite/content/users/index.es.md
+++ b/exampleSite/content/users/index.es.md
@@ -67,5 +67,6 @@ La lista a continuación es solo un puñado de sitios web creados con el tema Co
 | [josh-v.com](https://josh-v.com)                                       | Personal Site and Tech blog     |
 | [rshmhrj.io](https://rshmhrj.io/)                                      | Personal Site and Tech blog     |
 | [jamesjarvis.io](https://jamesjarvis.io)                               | Personal Site and Blog          |
+| [jnsgr.uk](https://jnsgr.uk)                                           | Personal site and blog          |
 
 **¿Usuaria de congo?** Para agregar tu sitio a esta lista, [haz un pull request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users/index.md).

--- a/exampleSite/content/users/index.ja.md
+++ b/exampleSite/content/users/index.ja.md
@@ -67,5 +67,6 @@ Congoを使用して構築された実際のウェブサイト。
 | [josh-v.com](https://josh-v.com)                                       | Personal Site and Tech blog     |
 | [rshmhrj.io](https://rshmhrj.io/)                                      | Personal Site and Tech blog     |
 | [jamesjarvis.io](https://jamesjarvis.io)                               | Personal Site and Blog          |
+| [jnsgr.uk](https://jnsgr.uk)                                           | Personal site and blog          |
 
 **Congoを使っていますか？** あなたのウェブサイトを加えるために[Pull Request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users/index.md)を投げてください。

--- a/exampleSite/content/users/index.md
+++ b/exampleSite/content/users/index.md
@@ -67,5 +67,6 @@ The list below is just a handful of the websites that are built using the Congo 
 | [josh-v.com](https://josh-v.com)                                       | Personal Site and Tech blog     |
 | [rshmhrj.io](https://rshmhrj.io/)                                      | Personal Site and Tech blog     |
 | [jamesjarvis.io](https://jamesjarvis.io)                               | Personal Site and Blog          |
+| [jnsgr.uk](https://jnsgr.uk)                                           | Personal site and blog          |
 
 **Congo user?** To add your site to this list, [submit a pull request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users/index.md).

--- a/exampleSite/content/users/index.zh-cn.md
+++ b/exampleSite/content/users/index.zh-cn.md
@@ -67,5 +67,6 @@ showEdit: false
 | [josh-v.com](https://josh-v.com)                                       | Personal Site and Tech blog     |
 | [rshmhrj.io](https://rshmhrj.io/)                                      | Personal Site and Tech blog     |
 | [jamesjarvis.io](https://jamesjarvis.io)                               | Personal Site and Blog          |
+| [jnsgr.uk](https://jnsgr.uk)                                           | Personal site and blog          |
 
 **想成为Congo的用户？** 要将您的网站添加到此列表中，请提交[Pull Request](https://github.com/jpanther/congo/blob/dev/exampleSite/content/users/index.md)来添加。


### PR DESCRIPTION
Simple change to add my personal site to the list of sites using `congo`. Also fixes a very minor alignment issue in one of the other entries as a drive-by.
