### PR TITLE
Fix picture partial img/source attributes

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,6 @@
       <div class="mb-12 mt-8 text-base text-neutral-500 print:hidden dark:text-neutral-400">
         {{ partial "article-meta.html" (dict "context" . "scope" "single") }}
       </div>
-      ß
       {{ with $feature }}
         <div class="prose">
           {{ $altText := $.Params.featureAlt | default $.Params.coverAlt | default "" }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,9 +10,17 @@
       <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
         {{ .Title | emojify }}
       </h1>
-      <div class="mb-12 mt-8 text-base text-neutral-500 print:hidden dark:text-neutral-400">
-        {{ partial "article-meta.html" (dict "context" . "scope" "single") }}
-      </div>
+      {{ if or
+        (.Params.showDate | default (.Site.Params.article.showDate | default true))
+        (and (.Params.showDateUpdated | default (.Site.Params.article.showDateUpdated | default false)) (ne (partial "functions/date.html" .Date) (partial "functions/date.html" .Lastmod)))
+        (and (.Params.showWordCount | default (.Site.Params.article.showWordCount | default false)) (ne .WordCount 0))
+        (and (.Params.showReadingTime | default (.Site.Params.article.showReadingTime | default true)) (ne .ReadingTime 0))
+        (.Params.showEdit | default (.Site.Params.article.showEdit | default false))
+      }}
+        <div class="mb-12 mt-8 text-base text-neutral-500 print:hidden dark:text-neutral-400">
+          {{ partial "article-meta.html" (dict "context" . "scope" "single") }}
+        </div>
+      {{ end }}
       {{ with $feature }}
         <div class="prose">
           {{ $altText := $.Params.featureAlt | default $.Params.coverAlt | default "" }}

--- a/layouts/partials/picture.html
+++ b/layouts/partials/picture.html
@@ -57,7 +57,7 @@
         <source
           {{ if lt .Width 660 }}
             {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
-              src="{{ .RelPermalink }}"
+              srcset="{{ .RelPermalink }}"
             {{ end }}
           {{ else }}
             srcset=" {{- (.Resize "330x webp").RelPermalink }} 330w,
@@ -70,19 +70,18 @@
               {{ end }}
             {{ end }}
             {{ if gt .Width 1320 }}
-              ,{{ (.Resize "1320x webp").RelPermalink }} 2x
+              ,{{ (.Resize "1320x webp").RelPermalink }} 1320w
             {{ else }}
               {{ with .Resize (printf "%dx%d webp" .Width .Height) }}
                 ,{{ .RelPermalink }} {{ .Width }}w
               {{ end }}
             {{ end }}"
-            src="{{ (.Resize "660x webp").RelPermalink }}"
           {{ end }}
+          sizes="100vw"
           type="image/webp"
         />
       {{ end }}
       <img
-        src="{{ .RelPermalink }}"
         width="{{ $width }}"
         height="{{ $height }}"
         {{ with $class }}class="{{ . }}"{{ end }}
@@ -91,20 +90,20 @@
         {{ if lt .Width 660 }}
           src="{{ .RelPermalink }}"
         {{ else }}
+          src="{{ (.Resize "660x").RelPermalink }}"
           srcset=" {{- (.Resize "330x").RelPermalink }} 330w,
-          {{- (.Resize "660x").RelPermalink }}
-          660w
+          {{- (.Resize "660x").RelPermalink }} 660w
           {{ if gt .Width 1024 }}
             ,{{ (.Resize "1024x").RelPermalink }} 1024w
           {{ else }}
             ,{{ .RelPermalink }} {{ .Width }}w
           {{ end }}
           {{ if gt .Width 1320 }}
-            ,{{ (.Resize "1320x").RelPermalink }} 2x
+            ,{{ (.Resize "1320x").RelPermalink }} 1320w
           {{ else }}
             ,{{ .RelPermalink }} {{ .Width }}w
           {{ end }}"
-          src="{{ (.Resize "660x").RelPermalink }}"
+          sizes="100vw"
         {{ end }}
       />
     </picture>


### PR DESCRIPTION
Remove duplicate src attribute from image tag.
Remove not allowed src attribute from source tag.
Add default sizes attributes to img and source tag.
Fix inconsistent srcset width.

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
