### PR TITLE
Revert "💄 Fix Safari status bar style"

### DIFF
--- a/assets/js/appearance.js
+++ b/assets/js/appearance.js
@@ -8,13 +8,9 @@ function getCSSValue(varName) {
 
 function setThemeColor() {
   var metaThemeColor = document.querySelector("meta[name=theme-color]");
-  var metaAppleMobileWebAppStatusBarStyle = document.querySelector("meta[name=apple-mobile-web-app-status-bar-style]");
   document.documentElement.classList.contains("dark")
     ? metaThemeColor.setAttribute("content", getCSSValue("--color-neutral-800"))
     : metaThemeColor.setAttribute("content", getCSSValue("--color-neutral"));
-  document.documentElement.classList.contains("dark")
-    ? metaAppleMobileWebAppStatusBarStyle.setAttribute("content", getCSSValue("--color-neutral-800"))
-    : metaAppleMobileWebAppStatusBarStyle.setAttribute("content", getCSSValue("--color-neutral"));
   return true;
 }
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="rgb(255,255,255)" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="rgb(255,255,255)" />
   {{/* Title */}}
   {{ if .IsHome -}}
     <title>{{ .Site.Title | emojify }}</title>


### PR DESCRIPTION
Reverts jpanther/congo#789

The theme-color tag is [supported](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color#browser_compatibility) by all Apple devices released since 2015 (iOS 15, available from 2021).

In addition, the meta tag apple-mobile-web-app-capable has no effect unless full-screen mode as described in apple-[apple-mobile-web-app-capable](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW3) is specified. A regular congo webpage should not run in full-screen mode.