### PR TITLE
🛠 fix: Space in rendered link

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,9 +1,9 @@
 {{- $link := .Destination -}}
 {{- $isRemote := strings.HasPrefix $link "http" -}}
 {{- if not $isRemote }}
-  {{ $url := urls.Parse .Destination }}
+  {{- $url := urls.Parse .Destination -}}
   {{- if $url.Path }}
-    {{ $fragment := "" }}
+    {{- $fragment := "" }}
     {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
     {{- with .Page.GetPage $url.Path }}
       {{ $link = printf "%s%s" .RelPermalink $fragment }}
@@ -14,5 +14,4 @@
     {{ end -}}
   {{ end -}}
 {{ end -}}
-<!-- prettier-ignore -->
-<a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank" rel="noreferrer"{{ end }}>{{- .Text | safeHTML -}}</a>
+<!-- prettier-ignore --><a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank" rel="noreferrer"{{ end }}>{{- .Text | safeHTML -}}</a>


### PR DESCRIPTION
When I have these in my markdwon:

```markdown
this[link]({{< relref "/series" >}})shouldnothaveanyspace

this[link](https://github.com/tomy0000000)shouldnothaveanyspace
```

an extra `\n` character is rendered in HTML, which is interpreted as a space before the link like this:

![CleanShot 2024-02-22 at 21 39 43@2x](https://github.com/jpanther/congo/assets/23290356/6b799bc7-ddbc-49fc-96fe-c02e40814b19)

where it should have been this:

![CleanShot 2024-02-22 at 21 42 24@2x](https://github.com/jpanther/congo/assets/23290356/a338030e-8415-4d09-acd3-8307a24c85a1)

This PR trimmed the newline characters and fixed the bug.
