### PR TITLE
:bug: Fix blank character prefix on links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -15,4 +15,5 @@
   {{ end -}}
 {{ end -}}
 <!-- prettier-ignore -->
+{{- /* the two "-" around this block removes the newline introduced by the HTML comment above */ -}}
 <a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank" rel="noreferrer"{{ end }}>{{- .Text | safeHTML -}}</a>


### PR DESCRIPTION
Caused by the "prettier-ignore" comment. Workaround is to remove the blank character using a comment template.

From https://gohugo.io/templates/base/#override-the-base-template:
> Code that you put outside the block definitions can break your layout. This even includes HTML comments.

Fixes #800 