### PR TITLE
Fixing Incorrect Language Codes in baseof.html Template

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,8 +2,8 @@
 {{- partial "partials/functions/init.html" . -}}
 <!doctype html>
 <html
-  lang="{{- site.Language.LanguageCode | default "" -}}"
-  dir="{{- site.Language.LanguageDirection | default "ltr" -}}"
+  lang="{{- .Site.Language.LanguageCode | default "" -}}"
+  dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}"
   class="scroll-smooth"
   data-default-appearance="{{- .Site.Params.defaultAppearance | default "light" -}}"
   data-auto-appearance="{{- .Site.Params.autoSwitchAppearance | default "true" -}}"


### PR DESCRIPTION
This change fixes incorrect language codes referenced in the `baseof.html` template by updating the lang attribute to use `.Site.Language.LanguageCode` instead of `site.Language.LanguageCode` and `.Site.Language.LanguageDirection` instead of `site.Language.LanguageDirection`, ensuring the HTML language matches the configuration.

### Current Code

```html
<html
  lang="{{- site.Language.LanguageCode | default "en" -}}"
  dir="{{- site.Language.LanguageDirection | default "ltr" -}}"
  class="scroll-smooth"
  data-default-appearance="{{- .Site.Params.defaultAppearance | default "light" -}}"
  data-auto-appearance="{{- .Site.Params.autoSwitchAppearance | default "true" -}}"
>
```

### Updated Code

```html
<html
  lang="{{- .Site.Language.Lang | default "en" -}}"
  dir="{{- .Site.Language.LanguageDirection | default "ltr" -}}"
  class="scroll-smooth"  
  data-default-appearance="{{- .Site.Params.defaultAppearance | default "light" -}}"
  data-auto-appearance="{{- .Site.Params.autoSwitchAppearance | default "true" -}}"
>
```

The updated code uses the correct properties to set the language and direction attributes. This will make the HTML output align with the site's language configuration settings.