### PR TITLE
:sparkles: add defaultThemeColor option

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -9,6 +9,8 @@ colorScheme = "congo"
 defaultAppearance = "light" # valid options: light or dark
 autoSwitchAppearance = true
 
+defaultThemeColor = "#FFFFFF"
+
 enableSearch = false
 enableCodeCopy = false
 enableImageLazyLoading = true

--- a/exampleSite/content/docs/configuration/index.ja.md
+++ b/exampleSite/content/docs/configuration/index.ja.md
@@ -127,6 +127,7 @@ Congoはテーマの機能を制御する多数の設定パラメーターを提
 |Name|Default|Description|
 |---|---|---|
 |`colorScheme`|`"congo"`|使用する配色。有効な値は `congo` (デフォルト), `avocado`, `cherry`, `fire`, `ocean`, `sapphire`, `slate` です。詳しくは [カラースキーム]({{< ref "getting-started#カラースキーム" >}})セクションを参照してください。|
+|`defaultThemeColor`|`"#FFFFFF"`|まだ翻訳されていません。|
 |`defaultAppearance`|`"light"`|デフォルトのテーマ外観、 `light` または `dark` のいずれか。|
 |`autoSwitchAppearance`|`true`|テーマの外観を訪問者のオペレーティングシステムの設定に基づいて自動的に切り替えるかどうか。常に `defaultAppearance` を使うようにするには `false` を設定します。|
 |`enableSearch`|`false`|サイト内検索を有効にするかどうか。検索機能を有効にするには `true` を設定します。検索機能は、[サイト設定](#サイト設定)の `outputs.home` が正しく設定されているかどうかに依存することに注意してください。|

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -127,6 +127,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 |Name|Default|Description|
 |---|---|---|
 |`colorScheme`|`"congo"`|The theme colour scheme to use. Valid values are `congo` (default), `avocado`, `cherry`, `fire`, `ocean`, `sapphire` and `slate`. Refer to the [Colour Schemes]({{< ref "getting-started#colour-schemes" >}}) section for more details.|
+|`defaultThemeColor`|`"#FFFFFF"`|The original value (before any scripts modify it) to use for the `theme-color` meta tag. The meta tag will be changed based on the theme (`light` or `dark`) but it is useful for services that source the original value this tag to display an accent color (e.g. Discord)|
 |`defaultAppearance`|`"light"`|The default theme appearance, either `light` or `dark`.|
 |`autoSwitchAppearance`|`true`|Whether the theme appearance automatically switches based upon the visitor's operating system preference. Set to `false` to force the site to always use the `defaultAppearance`.|
 |`enableSearch`|`false`|Whether site search is enabled. Set to `true` to enable search functionality. Note that the search feature depends on the `outputs.home` setting in the [site configuration](#site-configuration) being set correctly.|

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -125,6 +125,7 @@ Congo 提供了大量的配置参数，用于控制主题的功能。下表概�
 |名称|默认值|描述|
 |---|---|---|
 |`colorScheme`|`"congo"`|要使用的主题颜色方案。有效值为 `congo`（默认）、`avocado`、`cherry`、`fire`、`ocean`、`sapphire` 和 `slate`。有关详细信息，请参阅[颜色方案]({{< ref "getting-started#颜色方案" >}})部分。|
+|`defaultThemeColor`|`"#FFFFFF`|`theme-color` meta 标签的原值（在脚本修改它之前）。meta 标签会根据所选主题而变化（`light` 或 `dark`），但是一些软件（例如 Discord）会使用该标签的原值来显示主题色。|
 |`defaultAppearance`|`"light"`|默认的主题外观，可以是 `light` 或 `dark`。|
 |`autoSwitchAppearance`|`true`|主题外观是否根据访问者的操作系统首选项自动切换。设置为 `false` 以始终使用 `defaultAppearance`。|
 |`enableSearch`|`false`|是否启用站内搜索。设置为 `true` 以启用搜索功能。请注意，搜索功能取决于 [站点配置](#site-configuration) 中的 `outputs.home` 设置正确。|

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="rgb(255,255,255)" />
+  <meta name="theme-color" content="{{ .Site.Params.defaultThemeColor | default "#ffffff" }}" />
   {{/* Title */}}
   {{ if .IsHome -}}
     <title>{{ .Site.Title | emojify }}</title>


### PR DESCRIPTION
Some applications (such as Discord) use the `theme-color` meta tag to display an accent color on its embeds. Currently the theme-color will be changed when the page loads by a script to reflect the current theme of the page (dark or light), but Discord ignores this and takes the value off of the original HTML. Therefore we can safely set this tag to some color specified by the user and not break the theme-aware theme-color functionality.

P.S. I don't speak Japanese so it will be great if anyone could translate the documentation for the new param.