### PR TITLE
fix: rename author to params.author

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -11,6 +11,6 @@ demosite = "https://jpanther.github.io/congo/"
 tags = ["blog", "minimal", "responsive", "dark mode", "dark", "light", "tailwind", "personal"]
 features = ["syntax highlighting", "dark mode", "emoji"]
 
-[author]
+[params.author]
   name = "James Panther"
   homepage = "https://jamespanther.com/"


### PR DESCRIPTION
Addresses this warning:

```
WARN  [CONGO] Theme parameter `author` block in `languages.xx.toml` has been renamed to `params.author`. Please update your site configuration.
```