### PR TITLE
Fix search to always fetch index.json from /

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -108,9 +108,7 @@ function fetchJSON(path, callback) {
 }
 
 function buildIndex() {
-  var baseURL = wrapper.getAttribute("data-url");
-  baseURL = baseURL.replace(/\/?$/, "/");
-  fetchJSON(baseURL + "index.json", function (data) {
+  fetchJSON("/index.json", function (data) {
     var options = {
       shouldSort: true,
       ignoreLocation: true,


### PR DESCRIPTION
I got 404s when deploying to netlify because baseURL was a different domain from where it was deployed.

Sure, you could say that I should fix the config on my end (and I will.)

But this could still be simplified to just always fetch from the site root. Specifying the domain is wholly unnecessary.