### PR TITLE
Replace .Site.IsMultiLingual with hugo.IsMultilingual

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     <nav class="pb-4 text-base font-medium text-neutral-500 dark:text-neutral-400">
       <ul class="flex list-none flex-col sm:flex-row">
         {{ range .Site.Menus.footer }}
-          {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
+          {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not hugo.IsMultilingual)) }}
             {{ continue }}
           {{ end }}
           <li class="group mb-1 text-end sm:mb-0 sm:me-7 sm:last:me-0">

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -9,7 +9,7 @@
       <ul class="flex list-none flex-col text-end sm:flex-row">
         {{ if .Site.Menus.main }}
           {{ range .Site.Menus.main }}
-            {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
+            {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not hugo.IsMultilingual)) }}
               {{ continue }}
             {{ end }}
             <li class="group mb-1 sm:mb-0 sm:me-7 sm:last:me-0.5">

--- a/layouts/partials/header/hamburger.html
+++ b/layouts/partials/header/hamburger.html
@@ -25,7 +25,7 @@
             </li>
             {{ if .Site.Menus.main }}
               {{ range .Site.Menus.main }}
-                {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
+                {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not hugo.IsMultilingual)) }}
                   {{ continue }}
                 {{ end }}
                 <li class="group mb-1">

--- a/layouts/partials/header/hybrid.html
+++ b/layouts/partials/header/hybrid.html
@@ -25,7 +25,7 @@
             </li>
             {{ if .Site.Menus.main }}
               {{ range .Site.Menus.main }}
-                {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
+                {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not hugo.IsMultilingual)) }}
                   {{ continue }}
                 {{ end }}
                 <li class="group mb-1">
@@ -130,7 +130,7 @@
       <ul class="hidden list-none flex-row text-end sm:flex">
         {{ if .Site.Menus.main }}
           {{ range .Site.Menus.main }}
-            {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not site.IsMultiLingual)) }}
+            {{ if and (eq .Params.action "locale") (or (not page.IsTranslated) (not hugo.IsMultilingual)) }}
               {{ continue }}
             {{ end }}
             <li class="group mb-1 sm:mb-0 sm:me-7 sm:last:me-0">

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -9,7 +9,7 @@
 {{ with page }}
   {{ if .IsTranslated }}
     {{ $currentLang := .Page.Lang }}
-    {{ if site.IsMultiLingual }}
+    {{ if hugo.IsMultilingual }}
       <div class="group relative">
         <button
           class="group-dark:hover:text-primary-400 flex w-full items-center justify-end transition-colors group-hover:text-primary-600"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "exampleSite/public"
 
 [build.environment]
-HUGO_VERSION = "0.119.0"
+HUGO_VERSION = "0.133.0"
 HUGO_THEMESDIR = "../.."
 HUGO_THEME = "repo"
 TZ = "Australia/Melbourne"


### PR DESCRIPTION
Addresses this deprecation warning:

```
WARN  deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in a future release. Use hugo.IsMultilingual instead.
```

[hugo.IsMultilingual](https://gohugo.io/functions/hugo/ismultilingual/) was introduced in v0.124.0.
So merging this PR would effectively make that the minimum required version. (See failing pipelines on initial commit, which are only using v0.119.)
Maybe you want to hold off on merging this for the time being :smile: