### PR TITLE
fix: Removes follow_url part of sharing link for XING

### DIFF
--- a/data/sharing.json
+++ b/data/sharing.json
@@ -62,6 +62,6 @@
   "xing": {
     "icon": "xing",
     "title": "sharing.xing",
-    "url": "https://www.xing.com/spi/shares/new?url=%s&follow_url=https://www.xing.com/profile/Philip_Wille"
+    "url": "https://www.xing.com/spi/shares/new?url=%s"
   }
 }


### PR DESCRIPTION
This PR removes the follow_url part of the sharing link for XING, which contained the URL to my personal XING profile. I accidentally forgot to remove this in my previous PR (#933). The sharing functionality should be unaffected by this PR.

Sorry for the inconveniences!
 