### PR TITLE
Update package-lock versions to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugo-congo-theme",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hugo-congo-theme",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Got this git diff after pulling 2.10.0 and running npm install:

```diff
 {
   "name": "hugo-congo-theme",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hugo-congo-theme",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
```