### PR TITLE
Remove documentation on deprecated shortcode 'gist'

### DIFF
--- a/exampleSite/content/samples/rich-content/index.de.md
+++ b/exampleSite/content/samples/rich-content/index.de.md
@@ -24,12 +24,6 @@ Dieses Beispiel verwendet den Shortcode `twitter_simple`, um einen Tweet anzuzei
 
 Alternativ kann der Shortcode `tweet` verwendet werden, um eine vollständig formatierte Twitter-Kachel einzubetten.
 
-## Gist
-
-Der Shortcode `gist` kann verwendet werden, um einen Gist von GitHub einzubetten. Er erfordert zwei unbenannte Parameter: den Benutzernamen und die ID des Gist.
-
-{{< gist jpanther a873e1219ffeaa80a926bbe8255f348e >}}
-
 ## Vimeo
 
 Der Shortcode `vimeo_simple` bettet ein Video von Vimeo ein.

--- a/exampleSite/content/samples/rich-content/index.es.md
+++ b/exampleSite/content/samples/rich-content/index.es.md
@@ -24,12 +24,6 @@ Este ejemplo usa el shortcode `twitter_simple` para generar un Tweet. Requiere d
 
 Alternativamente, el shortcut `tweet` se puede usar para incrustar una tarjeta completa de Twitter.
 
-## Gist
-
-El shortcode `gist` se puede usar para incrustar un GitHub Gist. Requiere dos parámetros por posición: el nombre de usuario y el ID del Gist.
-
-{{< gist jpanther a873e1219ffeaa80a926bbe8255f348e >}}
-
 ## Vimeo
 
 El shortcode `vimeo_simple` insertará un video de Vimeo.

--- a/exampleSite/content/samples/rich-content/index.ja.md
+++ b/exampleSite/content/samples/rich-content/index.ja.md
@@ -24,12 +24,6 @@ Hugoには、リッチコンテンツのためのいくつかの[組み込みシ
 
 `tweet` ショートコードを使えば、完全にマークアップされたTwitterカードを埋め込むこともできます。
 
-## Gist
-
-`gist` ショートコードを使うと、GitHubのGistを埋め込むことができます。ユーザー名とGistのIDというパラメーターが必要です。
-
-{{< gist jpanther a873e1219ffeaa80a926bbe8255f348e >}}
-
 ## Vimeo
 
 `vimeo_simple` ショートコードでVimeoの動画を埋め込むことができます。

--- a/exampleSite/content/samples/rich-content/index.md
+++ b/exampleSite/content/samples/rich-content/index.md
@@ -24,12 +24,6 @@ This example uses the `twitter_simple` shortcode to output a Tweet. It requires 
 
 Alternatively, the `tweet` shortcode can be used to embed a fully marked up Twitter card.
 
-## Gist
-
-The `gist` shortcode can be used to embed a GitHub Gist. It requires two unnamed parameters: the username and ID of the Gist.
-
-{{< gist jpanther a873e1219ffeaa80a926bbe8255f348e >}}
-
 ## Vimeo
 
 The `vimeo_simple` shortcode will embed a Vimeo video.

--- a/exampleSite/content/samples/rich-content/index.zh-Hans.md
+++ b/exampleSite/content/samples/rich-content/index.zh-Hans.md
@@ -24,12 +24,6 @@ Hugo包含了多个[内置短代码](https://gohugo.io/content-management/shortc
 
 或者，可以使用 `tweet` 短代码来嵌入一个完全标记的Twitter卡片。
 
-## Gist
-
-`gist` 短代码可以用于嵌入GitHub Gist。它需要两个未命名参数：Gist的用户名和ID。
-
-{{< gist jpanther a873e1219ffeaa80a926bbe8255f348e >}}
-
 ## Vimeo
 
 `vimeo_simple` 短代码将嵌入Vimeo视频。


### PR DESCRIPTION
When running example site with latest released hugo version 0.143.1, a warning is displayed:

```
WARN  The "gist" shortcode was deprecated in v0.143.0 and will be removed in a future release.
See https://gohugo.io/shortcodes/gist for instructions to create a replacement.
```

This PR fixes that issue.