### PR TITLE
fix: Don’t markdownify dates

### DIFF
--- a/layouts/partials/meta/date-updated.html
+++ b/layouts/partials/meta/date-updated.html
@@ -1,4 +1,4 @@
 <time datetime="{{ . }}">
-  {{- i18n "article.date_updated" (dict "Date" (partial "functions/date.html" .)) | markdownify | emojify -}}
+  {{- i18n "article.date_updated" (dict "Date" (partial "functions/date.html" .)) | emojify -}}
 </time>
 {{- /* Trim EOF */ -}}

--- a/layouts/partials/meta/date.html
+++ b/layouts/partials/meta/date.html
@@ -1,4 +1,4 @@
 <time datetime="{{ . }}">
-  {{- i18n "article.date" (dict "Date" (partial "functions/date.html" .)) | markdownify | emojify -}}
+  {{- i18n "article.date" (dict "Date" (partial "functions/date.html" .)) | emojify -}}
 </time>
 {{- /* Trim EOF */ -}}


### PR DESCRIPTION
To prevent “ordered list” markup in languages like Danish and German dates are no longer markdownifed.

Date formates like: `2. January 2006` would be turned into ordered lists because of the period after 2.

I didn't remove `emojify`, but I think it would also make sense to remove it as the output from the `dateFormat` probably wouldn't contain any emojis either.

Fixes #1027
