### PR TITLE
bug: fix anchor hover color/behavior in dark mode

### DIFF
--- a/assets/css/compiled/main.css
+++ b/assets/css/compiled/main.css
@@ -2973,9 +2973,9 @@ code {
   background-color: rgba(var(--color-primary-900), var(--tw-bg-opacity, 1));
 }
 
-.group:hover .dark\:group-hover\:text-neutral-700:is(.dark *) {
+.group:hover .dark\:group-hover\:text-primary-700:is(.dark *) {
   --tw-text-opacity: 1;
-  color: rgba(var(--color-neutral-700), var(--tw-text-opacity, 1));
+  color: rgba(var(--color-primary-700), var(--tw-text-opacity, 1));
 }
 
 .group:hover .dark\:group-hover\:text-primary-400:is(.dark *) {


### PR DESCRIPTION
this PR fixes an issue with anchor hover links in dark mode.

in light mode, hovering your cursor next to an h2/h3/etc header triggers an anchor to appear in an accent color (based on your chosen color scheme). if you move your cursor away, the anchor fades quickly.

![5F83890E-94BC-4B9D-8695-8C4C7EEC13A5](https://github.com/user-attachments/assets/10f19e6f-9261-498b-b0f6-9605700a4b04)

currently, in dark mode, hovering your cursor next to the same h2/h3/etc header triggers an anchor to appear, but with a notable lack of color and odd "flashing" behavior: 

![FF9305B1-2191-4520-A3EB-CF6F3BAAA441](https://github.com/user-attachments/assets/20c03229-5b3d-41ad-a34b-4f878736c7bd)

this fix changes the relevant dark mode CSS class from `--color-neutral-700` to `--color-primary-700`. after implementing this change, anchor links in dark mode now appear in an appropriate accent color and with a smooth, non-flashing hover transition:

![108296AF-0541-4C16-AE84-16D7D8E3C407](https://github.com/user-attachments/assets/a5232568-2a98-45b7-bdc9-a28b4f208f8a)

(light mode is unaffected by this change.)
