### PR TITLE
Add missing space in the LINE sharing link

### DIFF
--- a/data/sharing.json
+++ b/data/sharing.json
@@ -52,8 +52,8 @@
   "line": {
     "icon": "line",
     "title": "sharing.line",
-    "url": "https://line.me/R/share?text=%s%s"
-  },
+    "url": "https://line.me/R/share?text=%s%%20%s"
+},
   "weibo": {
     "icon": "weibo",
     "title": "sharing.weibo",

--- a/data/sharing.json
+++ b/data/sharing.json
@@ -53,7 +53,7 @@
     "icon": "line",
     "title": "sharing.line",
     "url": "https://line.me/R/share?text=%s%%20%s"
-},
+  },
   "weibo": {
     "icon": "weibo",
     "title": "sharing.weibo",


### PR DESCRIPTION
The URL spec for LINE is:

https://developers.line.biz/en/docs/messaging-api/using-line-url-scheme/#sending-text-messages

A space is missing between the URL and blog title. Without it, the blog URL and the first word of the blog title would be concatenated. The LINE messenger would then interpret that as a URL, which is an invalid link.

I applied the same fix in Blowfish. Check the deployment preview there for a working exampleSite:

https://github.com/nunocoracao/blowfish/pull/2213
