### PR TITLE
layouts: correctly check for template existence

### DIFF
--- a/exampleSite/layouts/partials/home/custom.html
+++ b/exampleSite/layouts/partials/home/custom.html
@@ -1,9 +1,9 @@
 {{ $jsHome := resources.Get "js/home.js" | resources.Minify | resources.Fingerprint "sha512" }}
 <div id="page">
-  {{ partial "partials/home/page.html" . }}
+  {{ partial "home/page.html" . }}
 </div>
 <div id="profile" class="hidden h-full">
-  {{ partial "partials/home/profile.html" . }}
+  {{ partial "home/profile.html" . }}
 </div>
 <script
   defer

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,7 +21,7 @@
       >
     </div>
     {{ $header := print "header/" .Site.Params.header.layout ".html" }}
-    {{ if templates.Exists $header }}
+    {{ if templates.Exists ( printf "partials/%s" $header) }}
       {{ partial $header . }}
     {{ else }}
       {{ partial "header/basic.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ $partial := print "home/" .Site.Params.homepage.layout ".html" }}
-  {{ if templates.Exists $partial }}
+  {{ if templates.Exists ( printf "partials/%s" $partial) }}
     {{ partial $partial . }}
   {{ else }}
     {{ partial "home/page.html" . }}


### PR DESCRIPTION
https://github.com/jpanther/congo/commit/4e4b470915171a5855f3f2ea25851995aace8b55 fixed the theme for building with Hugo v0.146.0 or later but it doesn't correctly check for template existence. That is, if you set `homepage.layout` to `profile` this theme will still load the `page` layout.

Hugo's [templates.Exists](https://gohugo.io/functions/templates/exists/) function tests for the existence of templates relative to the `layouts` directory. The example code they provide uses `printf` to join the template name with the `_partials` directory, which would be `partials` instead for this theme.

```
{{ $partialPath := printf "headers/%s.html" .Type }}
{{ if templates.Exists ( printf "_partials/%s" $partialPath ) }}
  {{ partial $partialPath . }}
{{ else }}
  {{ partial "headers/default.html" . }}
{{ end }}
```

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
