### PR TITLE
layouts: update `partials` to `_partials`

### DIFF
--- a/layouts/_partials/article-link.html
+++ b/layouts/_partials/article-link.html
@@ -61,7 +61,7 @@
           {{ partial "badge.html" (i18n "article.draft" | emojify) }}
         </div>
       {{ end }}
-      {{ if templates.Exists "partials/extend-article-link.html" }}
+      {{ if templates.Exists "_partials/extend-article-link.html" }}
         {{ partial "extend-article-link.html" . }}
       {{ end }}
     </h3>

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -134,7 +134,7 @@
     </div>
   </div>
   {{/* Extend footer - eg. for extra scripts, etc. */}}
-  {{ if templates.Exists "partials/extend-footer.html" }}
+  {{ if templates.Exists "_partials/extend-footer.html" }}
     {{ partial "extend-footer.html" . }}
   {{ end }}
 </footer>

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -103,7 +103,7 @@
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink ($.Site.Title | emojify) | safeHTML }}
   {{ end -}}
   {{/* Icons */}}
-  {{ if templates.Exists "partials/favicons.html" }}
+  {{ if templates.Exists "_partials/favicons.html" }}
     {{ partialCached "favicons.html" .Site }}
   {{ else }}
     <link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | relURL }}" />
@@ -146,7 +146,7 @@
   {{/* Analytics */}}
   {{ partial "analytics.html" . }}
   {{/* Extend head - eg. for custom analytics scripts, etc. */}}
-  {{ if templates.Exists "partials/extend-head.html" }}
+  {{ if templates.Exists "_partials/extend-head.html" }}
     {{ partial "extend-head.html" . }}
   {{ end }}
 </head>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -21,7 +21,7 @@
       >
     </div>
     {{ $header := print "header/" .Site.Params.header.layout ".html" }}
-    {{ if templates.Exists ( printf "partials/%s" $header) }}
+    {{ if templates.Exists ( printf "_partials/%s" $header) }}
       {{ partial $header . }}
     {{ else }}
       {{ partial "header/basic.html" . }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -50,7 +50,7 @@
       {{ partial "sharing-links.html" . }}
       {{ partial "article-pagination.html" . }}
       {{ if .Params.showComments | default (.Site.Params.article.showComments | default false) }}
-        {{ if templates.Exists "partials/comments.html" }}
+        {{ if templates.Exists "_partials/comments.html" }}
           <div class="pt-3">
             <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
             <div class="pt-3">


### PR DESCRIPTION
Hugo v0.146.0 introduced a [new template system](https://gohugo.io/templates/new-templatesystem-overview/) that changed the structure of the `layouts` directory.

Commit https://github.com/jpanther/congo/commit/99d5cf8b28ce82377588310799420721943a3e65 updated this theme to support the new `layouts` directory structure but missed a few updates to `templates.Exists` calls. This patch fixes those calls.

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
