### PR TITLE
Fix code copy button when noClasses = true

### DIFF
--- a/assets/js/code.js
+++ b/assets/js/code.js
@@ -13,7 +13,7 @@ function createCopyButton(highlightDiv) {
 }
 
 async function copyCodeToClipboard(button, highlightDiv) {
-  const codeToCopy = highlightDiv.querySelector(":last-child > .chroma > code").innerText;
+  const codeToCopy = highlightDiv.querySelector(":last-child > pre > code").innerText;
   try {
     result = await navigator.permissions.query({ name: "clipboard-write" });
     if (result.state == "granted" || result.state == "prompt") {


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->

When `noClasses` is set to true, the `chroma` class is not defined on the `pre` tag. Using `pre` instead of the class to select the code block for the copy button ensures it works in both cases.

https://gohugo.io/content-management/syntax-highlighting/#noclasses