### PR TITLE
Insert rel into menu items if specified in params

### DIFF
--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -56,6 +56,7 @@
               <a
                 href="{{ .URL }}"
                 title="{{ .Title }}"
+                {{ with .Params.rel }}rel="{{ . }}"{{ end }}
                 {{ with .Params.target }}target="{{ . }}"{{ end }}
                 >{{ with .Params.icon }}
                   <span

--- a/layouts/_partials/header/basic.html
+++ b/layouts/_partials/header/basic.html
@@ -77,6 +77,7 @@
                 <a
                   href="{{ .URL }}"
                   title="{{ .Title }}"
+                  {{ with .Params.rel }}rel="{{ . }}"{{ end }}
                   {{ with .Params.target }}target="{{ . }}"{{ end }}
                   >{{ with .Params.icon }}
                     <span

--- a/layouts/_partials/header/hamburger.html
+++ b/layouts/_partials/header/hamburger.html
@@ -94,6 +94,7 @@
                       href="{{ .URL }}"
                       title="{{ .Title }}"
                       onclick="close_menu()"
+                      {{ with .Params.rel }}rel="{{ . }}"{{ end }}
                       {{ with .Params.target }}target="{{ . }}"{{ end }}
                       >{{ with .Params.icon }}
                         <span

--- a/layouts/_partials/header/hybrid.html
+++ b/layouts/_partials/header/hybrid.html
@@ -94,6 +94,7 @@
                       href="{{ .URL }}"
                       title="{{ .Title }}"
                       onclick="close_menu()"
+                      {{ with .Params.rel }}rel="{{ . }}"{{ end }}
                       {{ with .Params.target }}target="{{ . }}"{{ end }}
                       >{{ with .Params.icon }}
                         <span
@@ -198,6 +199,7 @@
                 <a
                   href="{{ .URL }}"
                   title="{{ .Title }}"
+                  {{ with .Params.rel }}rel="{{ . }}"{{ end }}
                   {{ with .Params.target }}target="{{ . }}"{{ end }}
                   >{{ with .Params.icon }}
                     <span


### PR DESCRIPTION
If `rel` is specified in the menu params, then insert it into the link parameter.

Fixes #1115