### PR TITLE
🐛 Remove .Author check from warnings partial

### DIFF
--- a/layouts/_partials/functions/warnings.html
+++ b/layouts/_partials/functions/warnings.html
@@ -7,6 +7,3 @@
 {{ if ne .Params.logo nil }}
   {{ warnf "[CONGO] Theme parameter `logo` has been renamed to `header.logo`. Please update your site configuration." }}
 {{ end }}
-{{ if .Author }}
-  {{ warnf "[CONGO] Theme parameter `author` block in `languages.xx.toml` has been renamed to `params.author`. Please update your site configuration." }}
-{{ end }}


### PR DESCRIPTION
<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->

Hugo v0.156.0 removed the deprecated `.Site.Author` field entirely, which turns the deprecation warning on line 10 of `warnings.html` into a hard build error.

The fix removes the `.Author` check since the field no longer exists in Hugo's site object and anyone still using the old config format would need to address far more than this warning.

Tested with `npm run example` (hugo build against example site) — builds clean across all 5 locales.

Fixes #1149