### PR TITLE
Declare alternate languages on translated pages

### DIFF
--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -145,6 +145,13 @@
   {{ partial "vendor.html" . }}
   {{/* Analytics */}}
   {{ partial "analytics.html" . }}
+  {{/* Declare alternates */}}
+  {{- if .IsTranslated -}}
+    <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+    {{- range .Translations -}}
+      <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+    {{- end -}}
+  {{- end -}}
   {{/* Extend head - eg. for custom analytics scripts, etc. */}}
   {{ if templates.Exists "_partials/extend-head.html" }}
     {{ partial "extend-head.html" . }}


### PR DESCRIPTION
This MR declares alternate languages explicitly, if a page is translated.

Why is this necessary? The sitemap already declares alternates:
```html
            <xhtml:link
              rel="alternate"
              hreflang="{{ .Language.Lang }}"
              href="{{ .Permalink }}"
              />{{ end }}
```
That does work, but for ahrefs this is not enough:
<img width="1566" height="828" alt="image" src="https://github.com/user-attachments/assets/959777e7-6892-4c6d-bc34-55b2f58331ab" />
(Feb 15 scan was after I deployed the fix on my site.)

<img width="450" alt="image" src="https://github.com/user-attachments/assets/5106d206-b79a-4506-9329-78d50af9f5c2" />

After the fix:
<img width="450"  alt="image" src="https://github.com/user-attachments/assets/365c4c99-3c38-4f97-befc-7e9f1019651e" />



Fix on `npm run example`:
<img width="1919" height="524" alt="image" src="https://github.com/user-attachments/assets/b0a19307-a9c9-4295-83dd-0d50bf645aa5" />
