### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.gitignore,.gitattributes,*.svg,package-lock.json,i18n,*.css,*.min.*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.gitignore,.gitattributes,*.svg,package-lock.json,i18n,*.css,*.min.*,.codespellrc
+skip = .git,.gitignore,.gitattributes,*.svg,package-lock.json,i18n,*.css,*.min.*,.codespellrc,*/lib/*,.npm,.cache,lighthouse.html,samples,*.de.toml,*.es.toml,*.de.md,*.es.md,*.ja.toml,*.zh-Hans.toml
 check-hidden = true
-# ignore-regex = 
+# ignore-regex =
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ TODO
 
 # MacOS 
 .DS_Store
+.npm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- `figure` shortcode would load recursively when using the `default` paramater ([#1074](https://github.com/jpanther/congo/issues/1074))
+- `figure` shortcode would load recursively when using the `default` parameter ([#1074](https://github.com/jpanther/congo/issues/1074))
 - Some partials not loading due to incorrect file paths ([#1075](https://github.com/jpanther/congo/pull/1075))
 
 ## [2.12.0] - 2025-06-22

--- a/exampleSite/content/docs/shortcodes/index.md
+++ b/exampleSite/content/docs/shortcodes/index.md
@@ -16,7 +16,7 @@ In addition to all the [default Hugo shortcodes](https://gohugo.io/content-manag
 
 The input is written in Markdown so you can format it however you please.
 
-By default, the alert is presented with an exclaimation triangle icon. To change the icon, include the icon name in the shortcode. Check out the [icon shortcode](#icon) for more details on using icons.
+By default, the alert is presented with an exclamation triangle icon. To change the icon, include the icon name in the shortcode. Check out the [icon shortcode](#icon) for more details on using icons.
 
 **Example:**
 

--- a/exampleSite/content/docs/version-2/_index.md
+++ b/exampleSite/content/docs/version-2/_index.md
@@ -86,7 +86,7 @@ The new image resizing features also provide full control over `alt` and `title`
 
 ## A whole lot more
 
-There's countless other minor changes to explore. From being able to display taxonomies on articles and list pages, to using the new `headline` author parameter to customise your homepage. There's also improved JSON-LD strucured data which further optimises SEO performance. Plus the entire theme has had extra polish to ensure a consistent design language.
+There's countless other minor changes to explore. From being able to display taxonomies on articles and list pages, to using the new `headline` author parameter to customise your homepage. There's also improved JSON-LD structured data which further optimises SEO performance. Plus the entire theme has had extra polish to ensure a consistent design language.
 
 :rocket: Check out the [full changelog](https://github.com/jpanther/congo/blob/dev/CHANGELOG.md) to learn more.
 

--- a/exampleSite/content/docs/version-2/upgrade/index.ja.md
+++ b/exampleSite/content/docs/version-2/upgrade/index.ja.md
@@ -85,7 +85,7 @@ Congo 2.0では新しいテーマ設定パラメーターが多数導入され�
 言語設定ファイルはこのような構造になっています:
 
 ```toml
-# config/_default/languagues.en.toml
+# config/_default/languages.en.toml
 
 languageCode = "en"
 languageName = "English"

--- a/exampleSite/content/docs/version-2/upgrade/index.md
+++ b/exampleSite/content/docs/version-2/upgrade/index.md
@@ -85,7 +85,7 @@ This step is optional if you do not need multilingual support, although completi
 The languages config file follows this structure:
 
 ```toml
-# config/_default/languagues.en.toml
+# config/_default/languages.en.toml
 
 languageCode = "en"
 languageName = "English"
@@ -150,7 +150,7 @@ The recommended settings are as follows, which includes any headings in the Mark
 
 ### Params.toml
 
-A number of new theme parameters have been introduced in Congo 2.0. Some minor changes are requried to existing configurations. Remember, the theme will always revert to a sensible default if a parameter is not provided.
+A number of new theme parameters have been introduced in Congo 2.0. Some minor changes are required to existing configurations. Remember, the theme will always revert to a sensible default if a parameter is not provided.
 
 The way that dark mode works in Congo has been changed to allow greater flexibility around configuration. The old `darkMode` and `darkToggle` parameters have been **removed and replaced** by three new parameters. These new options operate independently of each other, making it possible to force the appearance while still allowing the user to override.
 
@@ -159,7 +159,7 @@ The way that dark mode works in Congo has been changed to allow greater flexibil
 | --- | --- | --- | --- |
 | `defaultAppearance` | String | `"light"` | Default theme appearance; either `light` or `dark`.<br>:warning: _Setting this to `light` replicates the old `darkMode = false` setting, while `dark` replicates `darkMode = true`._ |
 | `autoSwitchAppearance` | Boolean | `true` | Whether the theme appearance automatically switches based upon the operating system preference. Set to `false` to force the site to always use the `defaultAppearance`. <br>:warning: _Setting this to `true` replicates the old `darkMode = "auto"` setting._ |
-| `showAppearanceSwitcher` | Boolean | `false` | Whether the theme appearance switcher is dispalyed in the site footer. <br>:warning: _This parameter replaces `darkToggle`._ |
+| `showAppearanceSwitcher` | Boolean | `false` | Whether the theme appearance switcher is displayed in the site footer. <br>:warning: _This parameter replaces `darkToggle`._ |
 <!-- prettier-ignore-end -->
 
 The following table outlines some other key **new parameters** that control new features in version 2:

--- a/exampleSite/content/docs/version-2/upgrade/index.zh-Hans.md
+++ b/exampleSite/content/docs/version-2/upgrade/index.zh-Hans.md
@@ -85,7 +85,7 @@ Congo 2.0 引入了许多新的主题配置参数。虽然主题会适应现有�
 语言配置文件遵循以下结构：
 
 ```toml
-# config/_default/languagues.en.toml
+# config/_default/languages.en.toml
 
 languageCode = "en"
 languageName = "English"
@@ -108,7 +108,7 @@ rtl = false
 语言配置文件遵循以下结构：
 
 ```toml
-# config/_default/languagues.en.toml
+# config/_default/languages.en.toml
 
 languageCode = "en"
 languageName = "English"


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

## Changes

### Configuration & Infrastructure
- Added `.codespellrc` configuration with comprehensive skip patterns
- Created GitHub Actions workflow to check spelling on push and PRs to `dev`
- Added `.npm/` to `.gitignore` (local cache directory)

### Skip Patterns
Configured to skip:
- Minified JS libraries (`*/lib/*`)
- Cache directories (`.npm`, `.cache`)
- Generated Lighthouse HTML report (`lighthouse.html`)
- Sample/demo content with Lorem Ipsum (`samples`)
- Non-English locale files (`*.de.md`, `*.es.md`, `*.de.toml`, `*.es.toml`, `*.ja.toml`, `*.zh-Hans.toml`)
- SVG, CSS, lock files, i18n directories

### Typo Fixes (9 fixes in 6 files)
All non-ambiguous, fixed automatically via `codespell -w`:
- `paramater` → `parameter` (CHANGELOG.md)
- `exclaimation` → `exclamation` (shortcodes docs)
- `strucured` → `structured` (version-2 announcement)
- `languagues` → `languages` (upgrade docs — English, Japanese, Chinese versions)
- `requried` → `required` (upgrade docs)
- `dispalyed` → `displayed` (upgrade docs)

### Historical Context
This project has had 55 prior commits fixing typos manually, demonstrating the value of automated spell-checking.

## Testing

- Codespell passes with zero errors after all fixes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
