### PR TITLE
🐛 Remove .Author check from warnings partial

### DIFF
--- a/layouts/_partials/functions/warnings.html
+++ b/layouts/_partials/functions/warnings.html
@@ -7,6 +7,3 @@
 {{ if ne .Params.logo nil }}
   {{ warnf "[CONGO] Theme parameter `logo` has been renamed to `header.logo`. Please update your site configuration." }}
 {{ end }}
-{{ if .Author }}
-  {{ warnf "[CONGO] Theme parameter `author` block in `languages.xx.toml` has been renamed to `params.author`. Please update your site configuration." }}
-{{ end }}


### PR DESCRIPTION
Hugo v0.156.0 removed the deprecated .Site.Author field, causing this deprecation warning to become a hard build error.

Fixes #1149

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
