### PR TITLE
feat: standard.site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Support for [standard.site](https://standard.site) publications and documents. Set `standardSite.publicationAtUri` to add a `site.standard.publication` discovery hint to the home page, and `standardSite.documentAtUri` on article front matter to add `site.standard.document` and `site.standard.publication` `<link>` tags to article pages.
+
 ## [2.14.0] - 2026-05-23
 
 ### Added

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -80,3 +80,6 @@ fingerprintAlgorithm = "sha256"
   # bing = ""
   # pinterest = ""
   # yandex = ""
+
+[standardSite]
+  # publicationAtUri = "at://did:plc:abc123/site.standard.publication/rkey"

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -189,6 +189,7 @@ Many of the article defaults here can be overridden on a per article basis by sp
 |`verification.bing`|_Not set_|The site verification string provided by Bing to be included in the site metadata.|
 |`verification.pinterest`|_Not set_|The site verification string provided by Pinterest to be included in the site metadata.|
 |`verification.yandex`|_Not set_|The site verification string provided by Yandex to be included in the site metadata.|
+|`standardSite.publicationAtUri`|_Not set_|The AT-URI of the [standard.site](https://standard.site) publication record for this site. When set, a `site.standard.publication` discovery hint `<link>` is added to the home page. Refer to the [Partials docs]({{< ref "partials#standardsite" >}}) for details.|
 <!-- prettier-ignore-end -->
 
 ## Other configuration files

--- a/exampleSite/content/docs/front-matter/index.md
+++ b/exampleSite/content/docs/front-matter/index.md
@@ -49,4 +49,5 @@ Front matter parameter default values are inherited from the theme's [base confi
 |`showSummary`|`list.showSummary`|Whether or not the article summary should be displayed on list pages.|
 |`summary`|Auto generated using `summaryLength` (see [site configuration]({{< ref "configuration#site-configuration" >}}))|When `showSummary` is enabled, this is the Markdown string to be used as the summary for this article.|
 |`xml`|`true` unless excluded by `sitemap.excludedKinds`|Whether or not this article is included in the generated `/sitemap.xml` file.|
+|`standardSite.documentAtUri`|_Not set_|The AT-URI of the [standard.site](https://standard.site) `site.standard.document` record for this article. When set, Congo emits `site.standard.document` and `site.standard.publication` `<link>` tags in the article `<head>`. Refer to the [Partials docs]({{< ref "partials#standardsite" >}}) for details.|
 <!-- prettier-ignore-end -->

--- a/exampleSite/content/docs/partials/index.md
+++ b/exampleSite/content/docs/partials/index.md
@@ -113,6 +113,16 @@ Custom icons can be added by providing your own icon assets in the `assets/icons
 
 Icons can also be used in article content by calling the [icon shortcode]({{< ref "shortcodes#icon" >}}).
 
+## Standard.site
+
+[Standard.site](https://standard.site) defines shared AT Protocol lexicons for long-form publishing. Congo can advertise a site as a `site.standard.publication` and individual articles as `site.standard.document` records by emitting the appropriate `<link>` tags in the page `<head>`.
+
+To enable this feature, set the AT-URI of your publication record on the `standardSite.publicationAtUri` site parameter. When set, Congo adds a `site.standard.publication` discovery hint `<link>` tag to the home page.
+
+To associate an individual article with its `site.standard.document` record, set the AT-URI on the `standardSite.documentAtUri` front matter parameter. When set, Congo emits both a `site.standard.document` verification `<link>` and a `site.standard.publication` reference on that article so consumers like Bluesky can render enhanced link cards without an extra lookup.
+
+You are still responsible for serving the `/.well-known/site.standard.publication` endpoint required by the [standard.site verification spec](https://standard.site/docs/verification/). The simplest way is to place a plain-text file containing your publication AT-URI at `static/.well-known/site.standard.publication`. Make sure your host serves it with a `Content-Type` of `text/plain`.
+
 ## Extensions
 
 Congo also provides for a number of extension partials that allow for expanding upon base functionality.

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -124,6 +124,8 @@
   {{ with .Site.Params.verification.yandex }}
     <meta name="yandex-verification" content="{{ . }}" />
   {{ end }}
+  {{/* standard.site */}}
+  {{ partial "standard-site.html" . }}
   {{ with $.Params.externalUrl }}
     <meta http-equiv="refresh" content="0; url={{ . }}" />
   {{ end }}

--- a/layouts/_partials/standard-site.html
+++ b/layouts/_partials/standard-site.html
@@ -1,0 +1,25 @@
+{{/*
+  Emit standard.site link tags.
+
+  - The home page emits a `site.standard.publication` discovery hint
+    when `standardSite.publicationAtUri` is set.
+  - Pages with `standardSite.documentAtUri` in their front matter emit
+    a `site.standard.document` verification link, and also re-emit the
+    publication link so consumers like Bluesky can resolve the parent
+    publication without an extra round-trip.
+
+  See https://standard.site/docs/verification/ and
+  https://github.com/bluesky-social/atproto/discussions/4978.
+*/}}
+{{ $documentAtUri := "" }}
+{{ with .Params.standardSite }}
+  {{ $documentAtUri = .documentAtUri }}
+{{ end }}
+{{ if or .IsHome $documentAtUri }}
+  {{ with .Site.Params.standardSite.publicationAtUri }}
+    <link rel="site.standard.publication" href="{{ . | safeURL }}" />
+  {{ end }}
+{{ end }}
+{{ with $documentAtUri }}
+  <link rel="site.standard.document" href="{{ . | safeURL }}" />
+{{ end }}


### PR DESCRIPTION
Added support for standard.site lexicons so people using ATProto get enhanced Bluesky links when sharing links to their site. The following lexicons are supported.
- site.standard.publication
- site.standard.document

See the changes in the `exampleSite` for documentation on how to use this.

<!-- IMPORTANT! Before submitting, ensure you have followed the Contributing guidelines. -->
<!-- https://github.com/jpanther/congo/blob/dev/CONTRIBUTING.md -->
